### PR TITLE
chore: add beta and next to prerelease branches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - main
       - alpha
+      - beta
+      - next
 jobs:
   release:
     name: Release

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,5 +1,10 @@
 {
-  "branches": [{ "name": "main" }, { "name": "alpha", "prerelease": true }],
+  "branches": [
+    { "name": "main" },
+    { "name": "alpha", "prerelease": true },
+    { "name": "beta", "prerelease": true },
+    { "name": "next", "prerelease": true }
+  ],
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",


### PR DESCRIPTION
Add `beta` and `next` to the release workflow in case we decide to name the prerelease branch something else, like it was done in [eik plugin for semantic-release](https://github.com/eik-lib/semantic-release/blob/master/.github/workflows/publish.yml#L7-L9).