### PR TITLE
feat: update how attentionEl's position should be controlled

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "typescript": "^4.7.4",
-    "@floating-ui/dom": "^1.6.1",
+    "@floating-ui/dom": "1.6.3",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
     "semantic-release": "^22.0.7",

--- a/package.json
+++ b/package.json
@@ -31,9 +31,6 @@
   "keywords": [],
   "author": "",
   "license": "Apache-2.0",
-  "dependencies": {
-    "@floating-ui/dom": "^1.5.4"
-  },
   "devDependencies": {
     "typescript": "^4.7.4",
     "@semantic-release/changelog": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "@floating-ui/dom": "^0.5.0"
+    "@floating-ui/dom": "^1.5.4"
   },
   "devDependencies": {
     "typescript": "^4.7.4",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "typescript": "^4.7.4",
+    "@floating-ui/dom": "^1.6.1",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
     "semantic-release": "^22.0.7",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "typescript": "^4.7.4",
-    "@floating-ui/dom": "1.6.3",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
     "semantic-release": "^22.0.7",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
   "files": [
     "dist"
   ],
+  "peerDependencies": {
+    "@floating-ui/dom": "1.6.3"
+  },
   "scripts": {
     "commit": "cz",
     "build": "tsc",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 devDependencies:
   '@floating-ui/dom':
-    specifier: ^1.6.1
-    version: 1.6.1
+    specifier: 1.6.3
+    version: 1.6.3
   '@semantic-release/changelog':
     specifier: ^6.0.3
     version: 6.0.3(semantic-release@22.0.7)
@@ -156,8 +156,8 @@ packages:
       '@floating-ui/utils': 0.2.1
     dev: true
 
-  /@floating-ui/dom@1.6.1:
-    resolution: {integrity: sha512-iA8qE43/H5iGozC3W0YSnVSW42Vh522yyM1gj+BqRwVsTNOyr231PsXDaV04yT39PsO0QL2QpbI/M0ZaLUQgRQ==}
+  /@floating-ui/dom@1.6.3:
+    resolution: {integrity: sha512-RnDthu3mzPlQ31Ss/BTwQ1zjzIhr3lk1gZB1OC56h/1vEtaXkESrOqL5fQVMfXpwGtRwX+YsZBdyHtJMQnkArw==}
     dependencies:
       '@floating-ui/core': 1.6.0
       '@floating-ui/utils': 0.2.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 devDependencies:
+  '@floating-ui/dom':
+    specifier: ^1.6.1
+    version: 1.6.1
   '@semantic-release/changelog':
     specifier: ^6.0.3
     version: 6.0.3(semantic-release@22.0.7)
@@ -146,6 +149,23 @@ packages:
       '@jridgewell/trace-mapping': 0.3.9
     dev: true
     optional: true
+
+  /@floating-ui/core@1.6.0:
+    resolution: {integrity: sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==}
+    dependencies:
+      '@floating-ui/utils': 0.2.1
+    dev: true
+
+  /@floating-ui/dom@1.6.1:
+    resolution: {integrity: sha512-iA8qE43/H5iGozC3W0YSnVSW42Vh522yyM1gj+BqRwVsTNOyr231PsXDaV04yT39PsO0QL2QpbI/M0ZaLUQgRQ==}
+    dependencies:
+      '@floating-ui/core': 1.6.0
+      '@floating-ui/utils': 0.2.1
+    dev: true
+
+  /@floating-ui/utils@0.2.1:
+    resolution: {integrity: sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q==}
+    dev: true
 
   /@jridgewell/resolve-uri@3.1.0:
     resolution: {integrity: sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,11 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-dependencies:
-  '@floating-ui/dom':
-    specifier: ^1.5.4
-    version: 1.5.4
-
 devDependencies:
   '@semantic-release/changelog':
     specifier: ^6.0.3
@@ -151,23 +146,6 @@ packages:
       '@jridgewell/trace-mapping': 0.3.9
     dev: true
     optional: true
-
-  /@floating-ui/core@1.5.3:
-    resolution: {integrity: sha512-O0WKDOo0yhJuugCx6trZQj5jVJ9yR0ystG2JaNAemYUWce+pmM6WUEFIibnWyEJKdrDxhm75NoSRME35FNaM/Q==}
-    dependencies:
-      '@floating-ui/utils': 0.2.1
-    dev: false
-
-  /@floating-ui/dom@1.5.4:
-    resolution: {integrity: sha512-jByEsHIY+eEdCjnTVu+E3ephzTOzkQ8hgUfGwos+bg7NlH33Zc5uO+QHz1mrQUOgIKKDD1RtS201P9NvAfq3XQ==}
-    dependencies:
-      '@floating-ui/core': 1.5.3
-      '@floating-ui/utils': 0.2.1
-    dev: false
-
-  /@floating-ui/utils@0.2.1:
-    resolution: {integrity: sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q==}
-    dev: false
 
   /@jridgewell/resolve-uri@3.1.0:
     resolution: {integrity: sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@floating-ui/dom':
-    specifier: ^0.5.0
-    version: 0.5.4
+    specifier: ^1.5.4
+    version: 1.5.4
 
 devDependencies:
   '@semantic-release/changelog':
@@ -152,14 +152,21 @@ packages:
     dev: true
     optional: true
 
-  /@floating-ui/core@0.7.3:
-    resolution: {integrity: sha512-buc8BXHmG9l82+OQXOFU3Kr2XQx9ys01U/Q9HMIrZ300iLc8HLMgh7dcCqgYzAzf4BkoQvDcXf5Y+CuEZ5JBYg==}
+  /@floating-ui/core@1.5.3:
+    resolution: {integrity: sha512-O0WKDOo0yhJuugCx6trZQj5jVJ9yR0ystG2JaNAemYUWce+pmM6WUEFIibnWyEJKdrDxhm75NoSRME35FNaM/Q==}
+    dependencies:
+      '@floating-ui/utils': 0.2.1
     dev: false
 
-  /@floating-ui/dom@0.5.4:
-    resolution: {integrity: sha512-419BMceRLq0RrmTSDxn8hf9R3VCJv2K9PUfugh5JyEFmdjzDo+e8U5EdR8nzKq8Yj1htzLm3b6eQEEam3/rrtg==}
+  /@floating-ui/dom@1.5.4:
+    resolution: {integrity: sha512-jByEsHIY+eEdCjnTVu+E3ephzTOzkQ8hgUfGwos+bg7NlH33Zc5uO+QHz1mrQUOgIKKDD1RtS201P9NvAfq3XQ==}
     dependencies:
-      '@floating-ui/core': 0.7.3
+      '@floating-ui/core': 1.5.3
+      '@floating-ui/utils': 0.2.1
+    dev: false
+
+  /@floating-ui/utils@0.2.1:
+    resolution: {integrity: sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q==}
     dev: false
 
   /@jridgewell/resolve-uri@3.1.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,10 +4,12 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-devDependencies:
+dependencies:
   '@floating-ui/dom':
     specifier: 1.6.3
     version: 1.6.3
+
+devDependencies:
   '@semantic-release/changelog':
     specifier: ^6.0.3
     version: 6.0.3(semantic-release@22.0.7)
@@ -154,18 +156,18 @@ packages:
     resolution: {integrity: sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==}
     dependencies:
       '@floating-ui/utils': 0.2.1
-    dev: true
+    dev: false
 
   /@floating-ui/dom@1.6.3:
     resolution: {integrity: sha512-RnDthu3mzPlQ31Ss/BTwQ1zjzIhr3lk1gZB1OC56h/1vEtaXkESrOqL5fQVMfXpwGtRwX+YsZBdyHtJMQnkArw==}
     dependencies:
       '@floating-ui/core': 1.6.0
       '@floating-ui/utils': 0.2.1
-    dev: true
+    dev: false
 
   /@floating-ui/utils@0.2.1:
     resolution: {integrity: sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q==}
-    dev: true
+    dev: false
 
   /@jridgewell/resolve-uri@3.1.0:
     resolution: {integrity: sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==}
@@ -679,6 +681,7 @@ packages:
   /callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
+    requiresBuild: true
     dev: true
 
   /cardinal@2.1.1:
@@ -2064,6 +2067,7 @@ packages:
   /parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
+    requiresBuild: true
     dependencies:
       callsites: 3.1.0
     dev: true
@@ -2250,6 +2254,7 @@ packages:
   /resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
+    requiresBuild: true
     dev: true
 
   /resolve-from@5.0.0:

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -8,18 +8,18 @@ import {
   ReferenceElement,
 } from '@floating-ui/dom'
 
-const TOPSTART = 'top-start'
+const TOP_START = 'top-start'
 const TOP = 'top'
-const TOPEND = 'top-end'
-const RIGHTSTART = 'right-start'
+const TOP_END = 'top-end'
+const RIGHT_START = 'right-start'
 const RIGHT = 'right'
-const RIGHTEND = 'right-end'
-const BOTTOMSTART = 'bottom-start'
+const RIGHT_END = 'right-end'
+const BOTTOM_START = 'bottom-start'
 const BOTTOM = 'bottom'
-const BOTTOMEND = 'bottom-end'
-const LEFTSTART = 'left-start'
+const BOTTOM_END = 'bottom-end'
+const LEFT_START = 'left-start'
 const LEFT = 'left'
-const LEFTEND = 'left-end'
+const LEFT_END = 'left-end'
 
 type Directions =
   | 'top'
@@ -36,61 +36,61 @@ type Directions =
   | 'left-end'
 
 export const opposites = {
-  [TOPSTART]: BOTTOMEND,
+  [TOP_START]: BOTTOM_END,
   [TOP]: BOTTOM,
-  [TOPEND]: BOTTOMSTART,
-  [BOTTOMSTART]: TOPEND,
+  [TOP_END]: BOTTOM_START,
+  [BOTTOM_START]: TOP_END,
   [BOTTOM]: TOP,
-  [BOTTOMEND]: TOPSTART,
-  [LEFTSTART]: RIGHTEND,
+  [BOTTOM_END]: TOP_START,
+  [LEFT_START]: RIGHT_END,
   [LEFT]: RIGHT,
-  [LEFTEND]: RIGHTSTART,
-  [RIGHTSTART]: LEFTEND,
+  [LEFT_END]: RIGHT_START,
+  [RIGHT_START]: LEFT_END,
   [RIGHT]: LEFT,
-  [RIGHTEND]: LEFTSTART,
+  [RIGHT_END]: LEFT_START,
 }
 
 export const arrowLabels = {
-  [TOPSTART]: '↑',
+  [TOP_START]: '↑',
   [TOP]: '↑',
-  [TOPEND]: '↑',
-  [BOTTOMSTART]: '↓',
+  [TOP_END]: '↑',
+  [BOTTOM_START]: '↓',
   [BOTTOM]: '↓',
-  [BOTTOMEND]: '↓',
-  [LEFTSTART]: '←',
+  [BOTTOM_END]: '↓',
+  [LEFT_START]: '←',
   [LEFT]: '←',
-  [LEFTEND]: '←',
-  [RIGHTSTART]: '→',
+  [LEFT_END]: '←',
+  [RIGHT_START]: '→',
   [RIGHT]: '→',
-  [RIGHTEND]: '→',
+  [RIGHT_END]: '→',
 }
 export const directions = [
-  TOPSTART,
+  TOP_START,
   TOP,
-  TOPEND,
-  BOTTOMSTART,
+  TOP_END,
+  BOTTOM_START,
   BOTTOM,
-  BOTTOMEND,
-  LEFTSTART,
+  BOTTOM_END,
+  LEFT_START,
   LEFT,
-  LEFTEND,
-  RIGHTSTART,
+  LEFT_END,
+  RIGHT_START,
   RIGHT,
-  RIGHTEND,
+  RIGHT_END,
 ]
 export const rotation: any = {
-  [LEFTSTART]: -45,
+  [LEFT_START]: -45,
   [LEFT]: -45,
-  [LEFTEND]: -45,
-  [TOPSTART]: 45,
+  [LEFT_END]: -45,
+  [TOP_START]: 45,
   [TOP]: 45,
-  [TOPEND]: 45,
-  [RIGHTSTART]: 135,
+  [TOP_END]: 45,
+  [RIGHT_START]: 135,
   [RIGHT]: 135,
-  [RIGHTEND]: 135,
-  [BOTTOMSTART]: -135,
+  [RIGHT_END]: 135,
+  [BOTTOM_START]: -135,
   [BOTTOM]: -135,
-  [BOTTOMEND]: -135,
+  [BOTTOM_END]: -135,
 }
 
 export type AttentionState = {
@@ -102,11 +102,7 @@ export type AttentionState = {
   attentionEl?: HTMLElement | null
   flip?: Boolean
   fallbackPlacements?: Directions[]
-  targetEl?: unknown
-  tooltip?: Boolean
-  popover?: Boolean
-  callout?: Boolean
-  highlight?: Boolean
+  targetEl?: ReferenceElement | null
   noArrow?: Boolean
   distance?: number
   skidding?: number
@@ -114,8 +110,8 @@ export type AttentionState = {
 }
 
 const middlePosition = 'calc(50% - 7px)'
-const isDirectionVertical = (name: string) =>
-  [TOPSTART, TOP, TOPEND, BOTTOMSTART, BOTTOM, BOTTOMEND].includes(name)
+const isDirectionVertical = (name: Directions) =>
+  [TOP_START, TOP, TOP_END, BOTTOM_START, BOTTOM, BOTTOM_END].includes(name)
 
 function computeCalloutArrow({
   actualDirection,
@@ -142,17 +138,18 @@ export async function useRecompute(state: AttentionState) {
   }
   if (state?.isCallout) return computeCalloutArrow(state)
   
-  const referenceEl: ReferenceElement = state?.targetEl as ReferenceElement
-  const floatingEl: HTMLElement = state?.attentionEl as unknown as HTMLElement
-  const arrowEl: HTMLElement = state?.arrowEl as unknown as HTMLElement
+  if (!state?.targetEl || !state?.attentionEl) return
   
-  if (!referenceEl || !floatingEl) return
+  const targetEl = state?.targetEl
+  const attentionEl = state?.attentionEl
+  const arrowEl = state?.arrowEl
   
-  computePosition(referenceEl, floatingEl, {
+  
+  computePosition(targetEl, attentionEl, {
     placement: state?.directionName ?? 'bottom',
     middleware: [
-      offset({ mainAxis: state?.distance ?? 8, crossAxis: state?.skidding ?? 0}), // offers flexibility over how to place the attentionEl (floatingEl) towards its targetEl (referenceEl) both on the x and y axis (horizontally and vertically).
-      state?.flip && flip({ //when flip is set to true it will move the attentionEl's (floatingEl's) placement to its opposite side or to the preferred placements if fallbackPlacements has a value
+      offset({ mainAxis: state?.distance ?? 8, crossAxis: state?.skidding ?? 0}), // offers flexibility over how to place the attentionEl towards its targetEl both on the x and y axis (horizontally and vertically).
+      state?.flip && flip({ //when flip is set to true it will move the attentionEl's placement to its opposite side or to the preferred placements if fallbackPlacements has a value
         fallbackAxisSideDirection: 'start',
         fallbackPlacements: state?.fallbackPlacements
       }),
@@ -162,10 +159,10 @@ export async function useRecompute(state: AttentionState) {
   }).then(({ x, y, middlewareData, placement }) => {
     state.actualDirection = placement
 
-    Object.assign(floatingEl.style, {
-      left: `${x}px`,
-      top: `${y}px`,
-    })
+      Object.assign(attentionEl?.style, {
+        left: `${x}px`,
+        top: `${y}px`,
+      })
 
     const side = placement.split('-')[0]
 
@@ -176,12 +173,12 @@ export async function useRecompute(state: AttentionState) {
       left: 'right',
     }[side]
 
-    const isRtl = window.getComputedStyle(floatingEl).direction === 'rtl' //checks whether the text direction of the attentionEl (floatingEl) is right-to-left. Helps to calculate the position of the arrowEl and ensure proper alignment 
+    const isRtl = window.getComputedStyle(attentionEl).direction === 'rtl' //checks whether the text direction of the attentionEl is right-to-left. Helps to calculate the position of the arrowEl and ensure proper alignment 
     const arrowDirection: any = opposites[placement]
     const arrowPlacement: any = arrowDirection.split('-')[1]
     const arrowRotation: any = rotation[arrowDirection]
 
-    if (middlewareData.arrow) {
+    if (middlewareData.arrow && arrowEl) {
       const { x, y } = middlewareData.arrow
       let top = ''
       let right = ''
@@ -231,13 +228,11 @@ export async function useRecompute(state: AttentionState) {
 }
 
 export const autoUpdatePosition = (state: AttentionState) => {
-  const referenceEl: ReferenceElement = state?.targetEl as ReferenceElement
-  const floatingEl: HTMLElement = state?.attentionEl as HTMLElement
-
-  // computePosition is only run once, so we need to wrap autoUpdate() around useRecompute() in order to recompute the attentionEl's (floatingEl's) position
+  // computePosition is only run once, so we need to wrap autoUpdate() around useRecompute() in order to recompute the attentionEl's position
   // autoUpdate add event listeners that are triggered on resize and on scroll and will keep calling the useRecompute(). 
   // autoUpdate returns a cleanup() function that removes the event listeners.
-  return autoUpdate(referenceEl, floatingEl, () => {
+  if (!state?.targetEl || !state?.attentionEl) return 
+  return autoUpdate(state?.targetEl, state?.attentionEl, () => {
     useRecompute(state)
   })
 }

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -5,36 +5,37 @@ import {
   shift,
   arrow,
   autoUpdate,
-  ReferenceElement
+  ReferenceElement,
 } from '@floating-ui/dom'
 
-const TOPSTART = "top-start";
-const TOP = "top";
-const TOPEND = "top-end";
-const RIGHTSTART = "right-start";
-const RIGHT = "right";
-const RIGHTEND ="right-end";
-const BOTTOMSTART = "bottom-start";
-const BOTTOM = "bottom";
-const BOTTOMEND = "bottom-end"
-const LEFTSTART = "left-start";
-const LEFT = "left";
-const LEFTEND = "left-end";
+const TOPSTART = 'top-start'
+const TOP = 'top'
+const TOPEND = 'top-end'
+const RIGHTSTART = 'right-start'
+const RIGHT = 'right'
+const RIGHTEND = 'right-end'
+const BOTTOMSTART = 'bottom-start'
+const BOTTOM = 'bottom'
+const BOTTOMEND = 'bottom-end'
+const LEFTSTART = 'left-start'
+const LEFT = 'left'
+const LEFTEND = 'left-end'
 
-type Directions =   | 'top'
-| 'top-start'
-| 'top-end'
-| 'right'
-| 'right-start'
-| 'right-end'
-| 'bottom'
-| 'bottom-start'
-| 'bottom-end'
-| 'left'
-| 'left-start'
-| 'left-end';
+type Directions =
+  | 'top'
+  | 'top-start'
+  | 'top-end'
+  | 'right'
+  | 'right-start'
+  | 'right-end'
+  | 'bottom'
+  | 'bottom-start'
+  | 'bottom-end'
+  | 'left'
+  | 'left-start'
+  | 'left-end'
 
-type FallbackDirection = | 'none' | 'start' | 'end';
+type FallbackDirection = 'none' | 'start' | 'end'
 
 export const opposites = {
   [TOPSTART]: BOTTOMEND,
@@ -49,24 +50,36 @@ export const opposites = {
   [RIGHTSTART]: LEFTEND,
   [RIGHT]: LEFT,
   [RIGHTEND]: LEFTSTART,
-};
+}
 
 export const arrowLabels = {
-  [TOPSTART]: "↑",
-  [TOP]: "↑",
-  [TOPEND]: "↑",
-  [BOTTOMSTART]: "↓",
-  [BOTTOM]: "↓",
-  [BOTTOMEND]: "↓",
-  [LEFTSTART]: "←",
-  [LEFT]: "←",
-  [LEFTEND]: "←",
-  [RIGHTSTART]: "→",
-  [RIGHT]: "→",
-  [RIGHTEND]: "→",
-
-};
-export const directions = [TOPSTART, TOP, TOPEND, BOTTOMSTART, BOTTOM, BOTTOMEND, LEFTSTART, LEFT, LEFTEND, RIGHTSTART, RIGHT, RIGHTEND];
+  [TOPSTART]: '↑',
+  [TOP]: '↑',
+  [TOPEND]: '↑',
+  [BOTTOMSTART]: '↓',
+  [BOTTOM]: '↓',
+  [BOTTOMEND]: '↓',
+  [LEFTSTART]: '←',
+  [LEFT]: '←',
+  [LEFTEND]: '←',
+  [RIGHTSTART]: '→',
+  [RIGHT]: '→',
+  [RIGHTEND]: '→',
+}
+export const directions = [
+  TOPSTART,
+  TOP,
+  TOPEND,
+  BOTTOMSTART,
+  BOTTOM,
+  BOTTOMEND,
+  LEFTSTART,
+  LEFT,
+  LEFTEND,
+  RIGHTSTART,
+  RIGHT,
+  RIGHTEND,
+]
 export const rotation: any = {
   [LEFTSTART]: -45,
   [LEFT]: -45,
@@ -80,52 +93,55 @@ export const rotation: any = {
   [BOTTOMSTART]: -135,
   [BOTTOM]: -135,
   [BOTTOMEND]: -135,
-};
+}
 
 export type AttentionState = {
-  isShowing?: boolean;
-  isCallout?: boolean;
-  actualDirection?: Directions;
-  directionName: Directions;
-  arrowEl?: HTMLElement | null;
-  attentionEl?: HTMLElement | null;
+  isShowing?: boolean
+  isCallout?: boolean
+  actualDirection?: Directions
+  directionName: Directions
+  arrowEl?: HTMLElement | null
+  attentionEl?: HTMLElement | null
   fallbackDirection?: FallbackDirection
-  targetEl?: unknown;
-  tooltip?: Boolean;
-  popover?: Boolean;
-  callout?: Boolean;
-  highlight?: Boolean;
-  noArrow?: Boolean;
-  distance?: number;
-  skidding?: number;
-  waitForDOM?: () => void;
-};
+  targetEl?: unknown
+  tooltip?: Boolean
+  popover?: Boolean
+  callout?: Boolean
+  highlight?: Boolean
+  noArrow?: Boolean
+  distance?: number
+  skidding?: number
+  waitForDOM?: () => void
+}
 
-const middlePosition = "calc(50% - 7px)";
-const isDirectionVertical = (name: string) => [TOPSTART, TOP, TOPEND, BOTTOMSTART, BOTTOM, BOTTOMEND].includes(name);
+const middlePosition = 'calc(50% - 7px)'
+const isDirectionVertical = (name: string) =>
+  [TOPSTART, TOP, TOPEND, BOTTOMSTART, BOTTOM, BOTTOMEND].includes(name)
 
 function computeCalloutArrow({
   actualDirection,
   directionName,
   arrowEl,
 }: AttentionState) {
-  if (!arrowEl) return;
+  if (!arrowEl) return
 
-  actualDirection = directionName;
+  actualDirection = directionName
 
   const arrowDirection = opposites[actualDirection]
   const arrowRotation = rotation[arrowDirection]
 
-  const directionIsVertical = isDirectionVertical(directionName);
-  arrowEl.style.left = directionIsVertical ? middlePosition : "";
-  arrowEl.style.top = !directionIsVertical ? middlePosition : "";
-  arrowEl.style.transform = `rotate(${arrowRotation}deg)`;
+  const directionIsVertical = isDirectionVertical(directionName)
+  arrowEl.style.left = directionIsVertical ? middlePosition : ''
+  arrowEl.style.top = !directionIsVertical ? middlePosition : ''
+  arrowEl.style.transform = `rotate(${arrowRotation}deg)`
 }
 
-export async function useRecompute (state: AttentionState) {  
-  if (!state?.isShowing)  return // we're not currently showing the element, no reason to recompute
+// export function observer(isShowing)
+
+export async function useRecompute(state: AttentionState) {
+  if (!state?.isShowing) return // we're not currently showing the element, no reason to recompute
   if (state?.waitForDOM) {
-    await state?.waitForDOM(); // wait for DOM to settle before computing
+    await state?.waitForDOM() // wait for DOM to settle before computing
   }
   if (state?.isCallout) {
     return computeCalloutArrow(state)
@@ -134,78 +150,120 @@ export async function useRecompute (state: AttentionState) {
   const referenceEl: ReferenceElement = state?.targetEl as ReferenceElement
   const floatingEl: HTMLElement = state?.attentionEl as unknown as HTMLElement
   const arrowEl: HTMLElement = state?.arrowEl as unknown as HTMLElement
-      
-      if (!referenceEl || !floatingEl) return
 
-        computePosition(referenceEl, floatingEl, {
-          placement: state?.directionName,
-          middleware: [
-            offset({ mainAxis: state?.distance, crossAxis: state?.skidding }),
-            flip({ fallbackAxisSideDirection: "start", fallbackStrategy: 'initialPlacement'}),
-            shift({ padding: 16 }),
-            !state?.noArrow && arrowEl && arrow({ element: arrowEl })]
-        }).then(({ x, y, middlewareData, placement}) => {
-          state.actualDirection = placement
-          console.log("state?.actualDirection: ", state?.actualDirection);
-          
-          Object.assign(floatingEl.style, {
-            left: `${x}px`,
-            top: `${y}px`,
-          })
-          
-          const side = placement.split("-")[0];
-          
-          const staticSide: any = {
-            top: "bottom",
-            right: "left",
-            bottom: "top",
-            left: "right"
-          }[side];
-  
-  
-          const isRtl = window.getComputedStyle(floatingEl).direction === 'rtl'
-          const arrowDirection: any = opposites[placement]
-          const arrowPlacement: any = arrowDirection.split("-")[1]
-          const arrowRotation: any = rotation[arrowDirection]
-          
-          if (middlewareData.arrow) {
-            const { x, y } = middlewareData.arrow
-            let top = ''
-            let right = ''
-            let bottom = ''
-            let left = ''
-  
-            if (arrowPlacement === "start") {
-              const value = typeof x === 'number' ? `calc(10px - ${arrowEl?.offsetWidth / 2}px)` : '';
-              top = typeof y === 'number' ? `calc(10px -  ${arrowEl?.offsetWidth / 2}px)` : '';
-              right = isRtl ? value : '';
-              left = isRtl ? '' : value;
-            } else if (arrowPlacement === "end") {
-              const value = typeof x === 'number' ? `calc(10px - ${arrowEl?.offsetWidth / 2}px)` : '';
-              right = isRtl ? '' : value;
-              left = isRtl ? value : '';
-              bottom = typeof y === 'number' ? `calc(10px - ${arrowEl?.offsetWidth / 2}px)` : '';
-            } else {
-              left = typeof x === 'number' ? `${x}px` : '';
-              top = typeof y === 'number' ? `${y}px` : '';
-            }
-  
-            Object.assign(arrowEl?.style || {}, {
-              top,
-              right,
-              bottom,
-              left,
-              [staticSide]: `${-arrowEl?.offsetWidth / 2}px`,
-              transform: `rotate(${arrowRotation}deg)`
-            });
-          }
-        });
+  if (!referenceEl || !floatingEl) return
 
-      return state
+  // We stop computing the position of the floatingEl when referenceEl is no longer in view:
+  const observer: IntersectionObserver = new IntersectionObserver((entries) => {
+    for (const entry of entries) {
+      if (state?.isShowing && !entry.isIntersecting) {
+        state.isShowing = false
+        console.log("state.isShowing: ", state.isShowing);
+      }
+    }
+  })
+
+  const observedElements = new Set<Element>()
+
+  if (referenceEl && !observedElements.has(referenceEl as Element)) {
+    observer.observe(referenceEl as Element)
+    observedElements.add(referenceEl as Element)
+  }
+  if (!state.isShowing) {
+    observer.unobserve(referenceEl as Element)
+    console.log("kommer vi hit?");
+    
+    observedElements.delete(referenceEl as Element)
+    return
+  }
+  
+  
+  computePosition(referenceEl, floatingEl, {
+    placement: state?.directionName,
+    middleware: [
+      offset({ mainAxis: state?.distance, crossAxis: state?.skidding }),
+      flip({
+        fallbackAxisSideDirection: 'start',
+        fallbackStrategy: 'initialPlacement',
+      }),
+      shift({ padding: 16 }),
+      !state?.noArrow && arrowEl && arrow({ element: arrowEl }),
+    ],
+  }).then(({ x, y, middlewareData, placement }) => {
+    state.actualDirection = placement
+    console.log('state?.actualDirection: ', state?.actualDirection)
+
+    Object.assign(floatingEl.style, {
+      left: `${x}px`,
+      top: `${y}px`,
+    })
+
+    const side = placement.split('-')[0]
+
+    const staticSide: any = {
+      top: 'bottom',
+      right: 'left',
+      bottom: 'top',
+      left: 'right',
+    }[side]
+
+    const isRtl = window.getComputedStyle(floatingEl).direction === 'rtl'
+    const arrowDirection: any = opposites[placement]
+    const arrowPlacement: any = arrowDirection.split('-')[1]
+    const arrowRotation: any = rotation[arrowDirection]
+
+    if (middlewareData.arrow) {
+      const { x, y } = middlewareData.arrow
+      let top = ''
+      let right = ''
+      let bottom = ''
+      let left = ''
+
+      if (arrowPlacement === 'start') {
+        const value =
+          typeof x === 'number'
+            ? `calc(10px - ${arrowEl?.offsetWidth / 2}px)`
+            : ''
+        top =
+          typeof y === 'number'
+            ? `calc(10px -  ${arrowEl?.offsetWidth / 2}px)`
+            : ''
+        right = isRtl ? value : ''
+        left = isRtl ? '' : value
+      } else if (arrowPlacement === 'end') {
+        const value =
+          typeof x === 'number'
+            ? `calc(10px - ${arrowEl?.offsetWidth / 2}px)`
+            : ''
+        right = isRtl ? '' : value
+        left = isRtl ? value : ''
+        bottom =
+          typeof y === 'number'
+            ? `calc(10px - ${arrowEl?.offsetWidth / 2}px)`
+            : ''
+      } else {
+        left = typeof x === 'number' ? `${x}px` : ''
+        top = typeof y === 'number' ? `${y}px` : ''
+      }
+
+      Object.assign(arrowEl?.style || {}, {
+        top,
+        right,
+        bottom,
+        left,
+        [staticSide]: `${-arrowEl?.offsetWidth / 2}px`,
+        transform: `rotate(${arrowRotation}deg)`,
+      })
+    }
+  })
+
+  return state
 }
 
 export const autoUpdatePosition = (state: AttentionState) => {
   const referenceEl: ReferenceElement = state?.targetEl as ReferenceElement
   const floatingEl: HTMLElement = state?.attentionEl as HTMLElement
-  return autoUpdate(referenceEl, floatingEl, () => { useRecompute(state) })
+  return autoUpdate(referenceEl, floatingEl, () => {
+    useRecompute(state)
+  })
 }

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -113,37 +113,78 @@ function computeCalloutArrow({
   arrowEl.style.top = !directionIsVertical ? middlePosition : "";
 }
 
-export function useRecompute(state: AttentionState) {
-  if (!state.isShowing) return // we're not currently showing the element, no reason to recompute
+export function updatePosition(state: AttentionState) {
+  if (!state.isShowing)  return // we're not currently showing the element, no reason to recompute
     state?.waitForDOM?.(); // wait for DOM to settle before computing
     if (state.isCallout) return computeCalloutArrow(state); // we don't move the callout box
     const referenceEl = state.targetEl as ReferenceElement
     const floatingEl = state.attentionEl as HTMLElement
     const arrowEl = state.arrowEl as HTMLElement
-  
-  autoUpdate(referenceEl, floatingEl, () => {
-    computePosition(referenceEl, floatingEl, {
-        placement: state.directionName,
-        middleware: [
-          offset(8),
-          flip(),
-          shift({ padding: 16 }),
-          arrowEl && arrow({ element: arrowEl })]
-      }).then(({ x, y, middlewareData, placement}) => {
-        state.actualDirection = placement;
-        Object.assign(state.attentionEl?.style || {}, {
-          left: `${x}px`,
-          top: `${y}px`,
-        });
 
-        if (middlewareData.arrow) {
-          const { x, y } = middlewareData.arrow;  
-          Object.assign(arrowEl?.style || {}, {
-            left: x ? `${x}px` : "",
-            // TODO: temporary fix, for some reason left-start and right-start positions the arrowEL slightly too far down on the attentionEl
-            top: y ? placement.includes("-start") ? `${y - 4}px` : `${y}px` : "",
+    autoUpdate(referenceEl, floatingEl, () => {
+      computePosition(referenceEl, floatingEl, {
+          placement: state.directionName,
+          middleware: [
+            offset(8),
+            flip(),
+            shift({ padding: 16 }),
+            arrowEl && arrow({ element: arrowEl })]
+        }).then(({ x, y, middlewareData, placement}) => {
+          state.actualDirection = placement;
+          console.log("actualDirection: ", state.actualDirection);
+          Object.assign(state.attentionEl?.style || {}, {
+            left: `${x}px`,
+            top: `${y}px`,
           });
-        }
-      });
-  });
+  
+          if (middlewareData.arrow) {
+            const { x, y } = middlewareData.arrow;  
+            Object.assign(arrowEl?.style || {}, {
+              left: x ? `${x}px` : "",
+              // TODO: temporary fix, for some reason left-start and right-start positions the arrowEL slightly too far down on the attentionEl
+              top: y ? placement.includes("-start") ? `${y - 4}px` : `${y}px` : "",
+            });
+          }
+        });
+    })
 }
+
+// export function updatePosition(state: AttentionState) {
+//   if (!state.isShowing)  return // we're not currently showing the element, no reason to recompute
+//     state?.waitForDOM?.(); // wait for DOM to settle before computing
+//     if (state.isCallout) return computeCalloutArrow(state); // we don't move the callout box
+//     const referenceEl = state.targetEl as ReferenceElement
+//     const floatingEl = state.attentionEl as HTMLElement
+//     const arrowEl = state.arrowEl as HTMLElement
+
+//     computePosition(referenceEl, floatingEl, {
+//         placement: state.directionName,
+//         middleware: [
+//           offset(8),
+//           flip(),
+//           shift({ padding: 16 }),
+//           arrowEl && arrow({ element: arrowEl })]
+//       }).then(({ x, y, middlewareData, placement}) => {
+//         state.actualDirection = placement;
+//         console.log("actualDirection: ", state.actualDirection);
+//         Object.assign(state.attentionEl?.style || {}, {
+//           left: `${x}px`,
+//           top: `${y}px`,
+//         });
+
+//         if (middlewareData.arrow) {
+//           const { x, y } = middlewareData.arrow;  
+//           Object.assign(arrowEl?.style || {}, {
+//             left: x ? `${x}px` : "",
+//             // TODO: temporary fix, for some reason left-start and right-start positions the arrowEL slightly too far down on the attentionEl
+//             top: y ? placement.includes("-start") ? `${y - 4}px` : `${y}px` : "",
+//           });
+//         }
+//       });
+// }
+
+// export function cleanUp(state: AttentionState) {
+//   const referenceEl = state.targetEl as ReferenceElement
+//   const floatingEl = state.attentionEl as HTMLElement
+//   autoUpdate(referenceEl, floatingEl, () => updatePosition(state))
+// }

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -137,7 +137,7 @@ function computeCalloutArrow({
 }
 
 export async function useRecompute(state: AttentionState) {
-  console.log("state.isShowing: ", state.isShowing);
+  console.log("state.isShowing beginning of useRecompute: ", state.isShowing);
   
   if (!state?.isShowing) return // we're not currently showing the element, no reason to recompute
   if (state?.waitForDOM) {
@@ -156,8 +156,10 @@ export async function useRecompute(state: AttentionState) {
   // const observer: IntersectionObserver = new IntersectionObserver((entries) => {
   //   for (const entry of entries) {
   //     if (state?.isShowing && !entry.isIntersecting) {
+  //       console.log("state.isShowing in observer before setting it to false: ", state.isShowing);
+
   //       state.isShowing = false
-  //       console.log("state.isShowing: ", state.isShowing);
+  //       console.log("state.isShowing in observer after setting it to false: ", state.isShowing);
   //     }
   //   }
   // })
@@ -260,6 +262,131 @@ export async function useRecompute(state: AttentionState) {
 
   return state
 }
+
+// export async function useRecompute(state: AttentionState) {
+//   console.log("state.isShowing beginning of useRecompute: ", state.isShowing);
+  
+//   if (state?.isCallout) {
+//     return computeCalloutArrow(state)
+//   }
+//   const referenceEl: ReferenceElement = state?.targetEl as ReferenceElement
+//   const floatingEl: HTMLElement = state?.attentionEl as unknown as HTMLElement
+//   const arrowEl: HTMLElement = state?.arrowEl as unknown as HTMLElement
+
+//   if (!referenceEl || !floatingEl) return
+  
+//   if (!state.isShowing) return // we're not currently showing the element, no reason to recompute
+
+//   // We stop computing the position of the floatingEl when referenceEl is no longer visible:
+//   const observer: IntersectionObserver = new IntersectionObserver((entries) => {
+//     for (const entry of entries) {
+//       if (state?.isShowing && !entry.isIntersecting) {
+//         state.isShowing = false
+//         console.log("state.isShowing in observer: ", state.isShowing);
+//       }
+//     }
+//   })
+//   const observedElements = new Set<Element>()
+
+    
+//     if (referenceEl && observedElements.has(referenceEl as Element)) {
+//       console.log("observedElements: ", observedElements);
+//       observer.unobserve(referenceEl as Element)
+//       observedElements.delete(referenceEl as Element)
+//     }
+  
+//   if (state?.waitForDOM) {
+//     await state?.waitForDOM() // wait for DOM to settle before computing
+//   }
+
+//   if (referenceEl && !observedElements.has(referenceEl as Element)) {
+//     observer.observe(referenceEl as Element)
+//     observedElements.add(referenceEl as Element)
+//   }
+
+
+//   computePosition(referenceEl, floatingEl, {
+//     placement: state?.directionName,
+//     middleware: [
+//       offset({ mainAxis: state?.distance ?? 8, crossAxis: state?.skidding ?? 0}),
+//       flip({
+//         fallbackAxisSideDirection: 'start',
+//         fallbackStrategy: 'initialPlacement',
+//       }),
+//       shift({ padding: 16 }),
+//       !state?.noArrow && arrowEl && arrow({ element: arrowEl }),
+//     ],
+//   }).then(({ x, y, middlewareData, placement }) => {
+//     state.actualDirection = placement
+//     console.log('state?.actualDirection: ', state?.actualDirection)
+
+//     Object.assign(floatingEl.style, {
+//       left: `${x}px`,
+//       top: `${y}px`,
+//     })
+
+//     const side = placement.split('-')[0]
+
+//     const staticSide: any = {
+//       top: 'bottom',
+//       right: 'left',
+//       bottom: 'top',
+//       left: 'right',
+//     }[side]
+
+//     const isRtl = window.getComputedStyle(floatingEl).direction === 'rtl'
+//     const arrowDirection: any = opposites[placement]
+//     const arrowPlacement: any = arrowDirection.split('-')[1]
+//     const arrowRotation: any = rotation[arrowDirection]
+
+//     if (middlewareData.arrow) {
+//       const { x, y } = middlewareData.arrow
+//       let top = ''
+//       let right = ''
+//       let bottom = ''
+//       let left = ''
+
+//       // Calculate the arrow-position depending on if placement has '-start' or 'end':
+//       if (arrowPlacement === 'start') {
+//         const value =
+//           typeof x === 'number'
+//             ? `calc(10px - ${arrowEl?.offsetWidth / 2}px)`
+//             : ''
+//         top =
+//           typeof y === 'number'
+//             ? `calc(10px -  ${arrowEl?.offsetWidth / 2}px)`
+//             : ''
+//         right = isRtl ? value : ''
+//         left = isRtl ? '' : value
+//       } else if (arrowPlacement === 'end') {
+//         const value =
+//           typeof x === 'number'
+//             ? `calc(10px - ${arrowEl?.offsetWidth / 2}px)`
+//             : ''
+//         right = isRtl ? '' : value
+//         left = isRtl ? value : ''
+//         bottom =
+//           typeof y === 'number'
+//             ? `calc(10px - ${arrowEl?.offsetWidth / 2}px)`
+//             : ''
+//       } else {
+//         left = typeof x === 'number' ? `${x}px` : ''
+//         top = typeof y === 'number' ? `${y}px` : ''
+//       }
+
+//       Object.assign(arrowEl?.style || {}, {
+//         top,
+//         right,
+//         bottom,
+//         left,
+//         [staticSide]: `${-arrowEl?.offsetWidth / 2}px`,
+//         transform: `rotate(${arrowRotation}deg)`,
+//       })
+//     }
+//   })
+
+//   return state
+// }
 
 export const autoUpdatePosition = (state: AttentionState) => {
   const referenceEl: ReferenceElement = state?.targetEl as ReferenceElement

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -1,5 +1,3 @@
-import { autoUpdate, computePosition, flip, offset, shift, arrow, ReferenceElement } from "@floating-ui/dom";
-
 const TOPSTART = "top-start";
 const TOP = "top";
 const TOPEND = "top-end";
@@ -78,23 +76,6 @@ export type AttentionState = {
   directionName: Directions;
   arrowEl?: HTMLElement | null;
   attentionEl?: HTMLElement | null;
-  targetEl?: unknown;
-  topStart?: Boolean; 
-  top?: Boolean;
-  topEnd?: Boolean;
-  rightStart?: Boolean;
-  right?: Boolean;
-  rightEnd?: Boolean;
-  bottomStart?: Boolean;
-  bottom?: Boolean;
-  bottomEnd?: Boolean;
-  leftStart?: Boolean;
-  left?: Boolean;
-  leftEnd?: Boolean;
-  tooltip?: Boolean;
-  popover?: Boolean;
-  callout?: Boolean;
-  noArrow?: Boolean;
   waitForDOM?: () => void;
 };
 
@@ -113,60 +94,11 @@ function computeCalloutArrow({
   arrowEl.style.top = !directionIsVertical ? middlePosition : "";
 }
 
-export function useRecompute(state: AttentionState, isMounted: any) {
-  console.log("state.isShowing: ", state.isShowing);
-  if (isMounted === true) {
-    console.log("isMounted true in useRecompute? ", isMounted);
-    
-    // if (!state.isShowing)  return // we're not currently showing the element, no reason to recompute
+export async function useRecompute (state: AttentionState, update: () => void) {
+    if (!state.isShowing)  return // we're not currently showing the element, no reason to recompute
       state?.waitForDOM?.(); // wait for DOM to settle before computing
       if (state.isCallout) return computeCalloutArrow(state); // we don't move the callout box
-      const referenceEl = state.targetEl as ReferenceElement
-      const floatingEl = state.attentionEl as HTMLElement
-      const arrowEl = state.arrowEl as HTMLElement
+      if (!state.attentionEl) return
 
-
-      async function update () {
-        console.log("are we being called by cleanup?, state.isShowing", state.isShowing);
-        
-        const position = await computePosition(referenceEl, floatingEl, {
-          placement: state.directionName,
-          middleware: [
-            offset(8),
-            flip(),
-            shift({ padding: 16 }),
-            arrowEl && arrow({ element: arrowEl })
-          ]
-        }) 
-        // @ts-ignore
-        
-        state.actualDirection = position.placement;
-        console.log("state.actualDirection: ", state.actualDirection);
-        Object.assign(state.attentionEl?.style || {}, {
-          left: `${position.x}px`,
-          top: `${position.y}px`,
-        });
-    
-        if (position.middlewareData.arrow) {
-          // @ts-ignore
-          const { x, y } = position.middlewareData.arrow;
-          if (state.arrowEl) {
-            Object.assign(arrowEl?.style || {}, {
-              left: x ? `${x}px` : "",
-              // TODO: temporary fix, for some reason left-start and right-start positions the arrowEL slightly too far down on the attentionEl
-              top: y ? position.placement.includes("-start") ? `${y - 4}px` : `${y}px` : "",
-            });
-          }
-        }
-      }
-      // @ts-ignore
-      const cleanup = autoUpdate(referenceEl, floatingEl, update);
-      if (!state.isShowing) {
-        console.log("kommer vi hit?, isMounted: ", isMounted);
-       cleanup()
-      } else {
-        console.log("kommer vi till elsen av useRecompute? ");
-        return
-      }
-  }
+      update()
 }

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -170,9 +170,9 @@ export async function useRecompute(state: AttentionState) {
     const arrowPlacement: string = arrowDirection.split('-')[1]
     const arrowRotation: number = rotation[arrowDirection]
     
-    if (middlewareData.arrow && state?.arrowEl) {
+    if (middlewareData?.arrow && state?.arrowEl) {
       const arrowEl: HTMLElement = state?.arrowEl
-      const { x, y } = middlewareData.arrow
+      const { x, y } = middlewareData?.arrow
       let top = ''
       let right = ''
       let bottom = ''

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -79,10 +79,18 @@ export type AttentionState = {
   arrowEl?: HTMLElement | null;
   attentionEl?: HTMLElement | null;
   targetEl?: unknown;
+  topStart?: Boolean; 
   top?: Boolean;
+  topEnd?: Boolean;
+  rightStart?: Boolean;
   right?: Boolean;
+  rightEnd?: Boolean;
+  bottomStart?: Boolean;
   bottom?: Boolean;
+  bottomEnd?: Boolean;
+  leftStart?: Boolean;
   left?: Boolean;
+  leftEnd?: Boolean;
   tooltip?: Boolean;
   popover?: Boolean;
   callout?: Boolean;
@@ -91,7 +99,7 @@ export type AttentionState = {
 };
 
 const middlePosition = "calc(50% - 7px)";
-const isDirectionVertical = (name: string) => [TOP, BOTTOM].includes(name);
+const isDirectionVertical = (name: string) => [TOPSTART, TOP, TOPEND, BOTTOMSTART, BOTTOM, BOTTOMEND].includes(name);
 function computeCalloutArrow({
   actualDirection,
   directionName,
@@ -108,7 +116,7 @@ function computeCalloutArrow({
 export async function useRecompute(state: AttentionState) {
   if (!state.isShowing) return; // we're not currently showing the element, no reason to recompute
   state?.waitForDOM?.(); // wait for DOM to settle before computing
-  if (state.isCallout) return computeCalloutArrow(state); // we don't move the callout box, only its arrow
+  if (state.isCallout) return computeCalloutArrow(state); // we don't move the callout box
   const position = await computePosition(
     state.targetEl as ReferenceElement,
     state.attentionEl as HTMLElement,

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -121,7 +121,6 @@ export async function useRecompute(state: AttentionState) {
     const referenceEl = state.targetEl as ReferenceElement
     const floatingEl = state.attentionEl as HTMLElement
     const arrowEl = state.arrowEl as HTMLElement
-    const floatingOffset = arrowEl ? Math.sqrt(2 * arrowEl.offsetWidth ** 2)/ 2 : 8;
   
     if (isMounted) {
       const update = async () => {
@@ -131,7 +130,7 @@ export async function useRecompute(state: AttentionState) {
           {
             placement: state.directionName,
             middleware: [
-              offset(floatingOffset),
+              offset(8),
               flip(),
               shift({ padding: 16 }),
               arrowEl && arrow({ element: arrowEl }),

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -143,9 +143,7 @@ export async function useRecompute(state: AttentionState) {
   if (state?.waitForDOM) {
     await state?.waitForDOM() // wait for DOM to settle before computing
   }
-  if (state?.isCallout) {
-    return computeCalloutArrow(state)
-  }
+  if (state?.isCallout) return computeCalloutArrow(state)
 
   const referenceEl: ReferenceElement = state?.targetEl as ReferenceElement
   const floatingEl: HTMLElement = state?.attentionEl as unknown as HTMLElement

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -114,6 +114,8 @@ export const arrowDirectionClassname = (dir: Directions) => {
 
   const side = (dir: Directions): Directions => dir.split('-')[0] as Directions
   const staticSide = (dir: Directions): Directions => opposites[side(dir)]
+  const arrowDirection = (dir: Directions): Directions => opposites[dir]
+  const arrowRotation = (dir: Directions): number => rotation[arrowDirection(dir)]
 
   const applyArrowStyles = (arrowEl: HTMLElement, arrowRotation: number, dir: Directions) => {
     Object.assign(arrowEl?.style, {
@@ -134,16 +136,13 @@ export const arrowDirectionClassname = (dir: Directions) => {
     
     actualDirection = directionName
 
-  const arrowDirection: Directions = opposites[actualDirection]
-  const arrowRotation: number = rotation[arrowDirection]
-
   const directionIsVertical: boolean = isDirectionVertical(directionName)
 
   Object.assign(arrowEl?.style || {}, {
     left: directionIsVertical ? middlePosition : '',
     top: !directionIsVertical ? middlePosition : '',
   })
-  applyArrowStyles(arrowEl, arrowRotation, actualDirection)
+  applyArrowStyles(arrowEl, arrowRotation(actualDirection), actualDirection)
 }
 
 export async function useRecompute(state: AttentionState) {
@@ -177,9 +176,7 @@ export async function useRecompute(state: AttentionState) {
       top: `${y}px`,
     })
     const isRtl = window.getComputedStyle(attentionEl).direction === 'rtl' //checks whether the text direction of the attentionEl is right-to-left. Helps to calculate the position of the arrowEl and ensure proper alignment 
-    const arrowDirection: Directions = opposites[placement]
-    const arrowPlacement: string = arrowDirection.split('-')[1]
-    const arrowRotation: number = rotation[arrowDirection]
+    const arrowPlacement: string = arrowDirection(placement).split('-')[1]
     
     if (middlewareData?.arrow && state?.arrowEl) {
       const arrowEl: HTMLElement = state?.arrowEl
@@ -223,7 +220,7 @@ export async function useRecompute(state: AttentionState) {
         bottom,
         left,
       })
-      applyArrowStyles(arrowEl, arrowRotation, placement)
+      applyArrowStyles(arrowEl, arrowRotation(placement), placement)
     }
   })
 

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -98,7 +98,5 @@ export async function useRecompute (state: AttentionState, update: () => void) {
     if (!state.isShowing)  return // we're not currently showing the element, no reason to recompute
       state?.waitForDOM?.(); // wait for DOM to settle before computing
       if (state.isCallout) return computeCalloutArrow(state); // we don't move the callout box
-      if (!state.attentionEl) return
-
       update()
 }

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -136,9 +136,9 @@ function computeCalloutArrow({
   arrowEl.style.transform = `rotate(${arrowRotation}deg)`
 }
 
-// export function observer(isShowing)
-
 export async function useRecompute(state: AttentionState) {
+  console.log("state.isShowing: ", state.isShowing);
+  
   if (!state?.isShowing) return // we're not currently showing the element, no reason to recompute
   if (state?.waitForDOM) {
     await state?.waitForDOM() // wait for DOM to settle before computing
@@ -150,38 +150,38 @@ export async function useRecompute(state: AttentionState) {
   const referenceEl: ReferenceElement = state?.targetEl as ReferenceElement
   const floatingEl: HTMLElement = state?.attentionEl as unknown as HTMLElement
   const arrowEl: HTMLElement = state?.arrowEl as unknown as HTMLElement
-
+  
   if (!referenceEl || !floatingEl) return
-
-  // We stop computing the position of the floatingEl when referenceEl is no longer in view:
-  const observer: IntersectionObserver = new IntersectionObserver((entries) => {
-    for (const entry of entries) {
-      if (state?.isShowing && !entry.isIntersecting) {
-        state.isShowing = false
-        console.log("state.isShowing: ", state.isShowing);
-      }
-    }
-  })
-
-  const observedElements = new Set<Element>()
-
-  if (referenceEl && !observedElements.has(referenceEl as Element)) {
-    observer.observe(referenceEl as Element)
-    observedElements.add(referenceEl as Element)
-  }
-  if (!state.isShowing) {
-    observer.unobserve(referenceEl as Element)
-    console.log("kommer vi hit?");
-    
-    observedElements.delete(referenceEl as Element)
-    return
-  }
+  // We stop computing the position of the floatingEl when referenceEl is no longer visible:
+  // const observer: IntersectionObserver = new IntersectionObserver((entries) => {
+  //   for (const entry of entries) {
+  //     if (state?.isShowing && !entry.isIntersecting) {
+  //       state.isShowing = false
+  //       console.log("state.isShowing: ", state.isShowing);
+  //     }
+  //   }
+  // })
+  // const observedElements = new Set<Element>()
   
-  
+  // if (!state?.isShowing) {
+  //   if (referenceEl && observedElements.has(referenceEl as Element)) {
+  //     observer.unobserve(referenceEl as Element)
+  //     observedElements.delete(referenceEl as Element)
+  //   }
+  //   return // we're not currently showing the element, no reason to recompute
+  // }
+
+
+  // if (referenceEl && !observedElements.has(referenceEl as Element)) {
+  //   observer.observe(referenceEl as Element)
+  //   observedElements.add(referenceEl as Element)
+  // }
+
+
   computePosition(referenceEl, floatingEl, {
     placement: state?.directionName,
     middleware: [
-      offset({ mainAxis: state?.distance, crossAxis: state?.skidding }),
+      offset({ mainAxis: state?.distance ?? 8, crossAxis: state?.skidding ?? 0}),
       flip({
         fallbackAxisSideDirection: 'start',
         fallbackStrategy: 'initialPlacement',
@@ -219,6 +219,7 @@ export async function useRecompute(state: AttentionState) {
       let bottom = ''
       let left = ''
 
+      // Calculate the arrow-position depending on if placement has '-start' or 'end':
       if (arrowPlacement === 'start') {
         const value =
           typeof x === 'number'

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -1,29 +1,74 @@
 import { computePosition, flip, offset, shift, arrow, ReferenceElement } from "@floating-ui/dom";
 
+const TOPSTART = "top-start";
 const TOP = "top";
-const BOTTOM = "bottom";
-const LEFT = "left";
+const TOPEND = "top-end";
+const RIGHTSTART = "right-start";
 const RIGHT = "right";
-type Directions = "top" | "right" | "bottom" | "left";
+const RIGHTEND ="right-end";
+const BOTTOMSTART = "bottom-start";
+const BOTTOM = "bottom";
+const BOTTOMEND = "bottom-end"
+const LEFTSTART = "left-start";
+const LEFT = "left";
+const LEFTEND = "left-end";
+
+type Directions =   | 'top'
+| 'top-start'
+| 'top-end'
+| 'right'
+| 'right-start'
+| 'right-end'
+| 'bottom'
+| 'bottom-start'
+| 'bottom-end'
+| 'left'
+| 'left-start'
+| 'left-end';
 
 export const opposites = {
+  [TOPSTART]: BOTTOMSTART,
   [TOP]: BOTTOM,
+  [TOPEND]: BOTTOMEND,
+  [BOTTOMSTART]: TOPSTART,
   [BOTTOM]: TOP,
+  [BOTTOMEND]: TOPEND,
+  [LEFTSTART]: RIGHTSTART,
   [LEFT]: RIGHT,
+  [LEFTEND]: RIGHTEND,
+  [RIGHTSTART]: LEFTSTART,
   [RIGHT]: LEFT,
+  [RIGHTEND]: LEFTEND,
 };
 export const arrowLabels = {
+  [TOPSTART]: "↑",
   [TOP]: "↑",
+  [TOPEND]: "↑",
+  [BOTTOMSTART]: "↓",
   [BOTTOM]: "↓",
+  [BOTTOMEND]: "↓",
+  [LEFTSTART]: "←",
   [LEFT]: "←",
+  [LEFTEND]: "←",
+  [RIGHTSTART]: "→",
   [RIGHT]: "→",
+  [RIGHTEND]: "→",
+
 };
-export const directions = [TOP, BOTTOM, LEFT, RIGHT];
+export const directions = [TOPSTART, TOP, TOPEND, BOTTOMSTART, BOTTOM, BOTTOMEND, LEFTSTART, LEFT, LEFTEND, RIGHTSTART, RIGHT, RIGHTEND];
 export const rotation = {
+  [LEFTSTART]: -45,
   [LEFT]: -45,
+  [LEFTEND]: -45,
+  [TOPSTART]: 45,
   [TOP]: 45,
+  [TOPEND]: 45,
+  [RIGHTSTART]: 135,
   [RIGHT]: 135,
+  [RIGHTEND]: 135,
+  [BOTTOMSTART]: -135,
   [BOTTOM]: -135,
+  [BOTTOMEND]: -135,
 };
 
 export type AttentionState = {
@@ -62,7 +107,7 @@ function computeCalloutArrow({
 
 export async function useRecompute(state: AttentionState) {
   if (!state.isShowing) return; // we're not currently showing the element, no reason to recompute
-  await state?.waitForDOM?.(); // wait for DOM to settle before computing
+  state?.waitForDOM?.(); // wait for DOM to settle before computing
   if (state.isCallout) return computeCalloutArrow(state); // we don't move the callout box, only its arrow
   const position = await computePosition(
     state.targetEl as ReferenceElement,
@@ -80,13 +125,13 @@ export async function useRecompute(state: AttentionState) {
     }
   );
   // @ts-ignore
-  state.actualDirection = position.placement;
+ state.actualDirection = position.placement;
   Object.assign(state.attentionEl?.style || {}, {
-    left: "0",
-    top: "0",
-    transform: `translate3d(${Math.round(position.x)}px, ${Math.round(
-      position.y
-    )}px, 0)`,
+    left: `${position.x}px`,
+    top: `${position.y}px`,
+    // transform: `translate3d(${Math.round(position.x)}px, ${Math.round(
+    //   position.y
+    // )}px, 0)`,
   });
   // @ts-ignore
   let { x, y } = position.middlewareData.arrow;

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -36,18 +36,18 @@ const LEFT: Directions = 'left'
 const LEFT_END: Directions = 'left-end'
 
 export const directions: Directions[] = [
-  'top-start',
-  'top',
-  'top-end',
-  'right-start',
-  'right',
-  'right-end',
-  'bottom-start',
-  'bottom',
-  'bottom-end',
-  'left-start',
-  'left',
-  'left-end']
+  TOP_START,
+  TOP,
+  TOP_END,
+  RIGHT_START,
+  RIGHT,
+  RIGHT_END,
+  BOTTOM_START,
+  BOTTOM,
+  BOTTOM_END,
+  LEFT_START,
+  LEFT,
+  LEFT_END]
 
 export const opposites: Record<Directions, Directions> = {
   [TOP_START]: BOTTOM_END,

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -136,9 +136,6 @@ function computeCalloutArrow({
 }
 
 export async function useRecompute(state: AttentionState) {
-  console.log("state.isShowing beginning of useRecompute: ", state?.isShowing);
-  
-  
   if (!state?.isShowing) return // we're not currently showing the element, no reason to recompute
   if (state?.waitForDOM) {
     await state?.waitForDOM() // wait for DOM to settle before computing
@@ -154,8 +151,8 @@ export async function useRecompute(state: AttentionState) {
   computePosition(referenceEl, floatingEl, {
     placement: state?.directionName ?? 'bottom',
     middleware: [
-      offset({ mainAxis: state?.distance ?? 8, crossAxis: state?.skidding ?? 0}),
-      state?.flip && flip({
+      offset({ mainAxis: state?.distance ?? 8, crossAxis: state?.skidding ?? 0}), // offers flexibility over how to place the attentionEl (floatingEl) towards its targetEl (referenceEl) both on the x and y axis (horizontally and vertically).
+      state?.flip && flip({ //when flip is set to true it will move the attentionEl's (floatingEl's) placement to its opposite side or to the preferred placements if fallbackPlacements has a value
         fallbackAxisSideDirection: 'start',
         fallbackPlacements: state?.fallbackPlacements
       }),
@@ -164,7 +161,6 @@ export async function useRecompute(state: AttentionState) {
     ],
   }).then(({ x, y, middlewareData, placement }) => {
     state.actualDirection = placement
-    console.log('state?.actualDirection: ', state?.actualDirection)
 
     Object.assign(floatingEl.style, {
       left: `${x}px`,
@@ -180,7 +176,7 @@ export async function useRecompute(state: AttentionState) {
       left: 'right',
     }[side]
 
-    const isRtl = window.getComputedStyle(floatingEl).direction === 'rtl'
+    const isRtl = window.getComputedStyle(floatingEl).direction === 'rtl' //checks whether the text direction of the attentionEl (floatingEl) is right-to-left. Helps to calculate the position of the arrowEl and ensure proper alignment 
     const arrowDirection: any = opposites[placement]
     const arrowPlacement: any = arrowDirection.split('-')[1]
     const arrowRotation: any = rotation[arrowDirection]
@@ -192,7 +188,7 @@ export async function useRecompute(state: AttentionState) {
       let bottom = ''
       let left = ''
 
-      // Calculate the arrow-position depending on if placement has '-start' or 'end':
+      // calculates the arrow-position depending on if placement has '-start' or 'end'.:
       if (arrowPlacement === 'start') {
         const value =
           typeof x === 'number'
@@ -237,6 +233,10 @@ export async function useRecompute(state: AttentionState) {
 export const autoUpdatePosition = (state: AttentionState) => {
   const referenceEl: ReferenceElement = state?.targetEl as ReferenceElement
   const floatingEl: HTMLElement = state?.attentionEl as HTMLElement
+
+  // computePosition is only run once, so we need to wrap autoUpdate() around useRecompute() in order to recompute the attentionEl's (floatingEl's) position
+  // autoUpdate add event listeners that are triggered on resize and on scroll and will keep calling the useRecompute(). 
+  // autoUpdate returns a cleanup() function that removes the event listeners.
   return autoUpdate(referenceEl, floatingEl, () => {
     useRecompute(state)
   })

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -94,6 +94,7 @@ export type AttentionState = {
   tooltip?: Boolean;
   popover?: Boolean;
   callout?: Boolean;
+  highlight?: Boolean;
   noArrow?: Boolean;
   waitForDOM?: () => void;
 };
@@ -113,11 +114,6 @@ function computeCalloutArrow({
   const arrowDirection = opposites[actualDirection]
   const arrowRotation = rotation[arrowDirection]
 
-  console.log("arrowDirection callout: ", arrowDirection);
-  console.log("arrowRotation callout: ", arrowRotation);
-  
-  
-
   const directionIsVertical = isDirectionVertical(directionName);
   arrowEl.style.left = directionIsVertical ? middlePosition : "";
   arrowEl.style.top = !directionIsVertical ? middlePosition : "";
@@ -125,96 +121,89 @@ function computeCalloutArrow({
 }
 
 export async function useRecompute (state: AttentionState) {  
-  if (!state.isShowing)  return // we're not currently showing the element, no reason to recompute
+  if (!state?.isShowing)  return // we're not currently showing the element, no reason to recompute
   if (state?.waitForDOM) {
-    await state.waitForDOM(); // wait for DOM to settle before computing
+    await state?.waitForDOM(); // wait for DOM to settle before computing
   }
-  if (state.isCallout) {
-    console.log("kommer vi till callout?");
+  if (state?.isCallout) {
     return computeCalloutArrow(state)
   }
-  const referenceEl: ReferenceElement = state.targetEl as ReferenceElement
-  const floatingEl: HTMLElement = state.attentionEl as unknown as HTMLElement
-  const arrowEl: HTMLElement = state.arrowEl as unknown as HTMLElement
-  console.log("arrowEl: ", arrowEl);
-  
 
-  if (!state.noArrow) {
-  }
+  const referenceEl: ReferenceElement = state?.targetEl as ReferenceElement
+  const floatingEl: HTMLElement = state?.attentionEl as unknown as HTMLElement
+  const arrowEl: HTMLElement = state?.arrowEl as unknown as HTMLElement
       
-      if (!floatingEl) return
-      computePosition(referenceEl, floatingEl, {
-        placement: state.directionName,
-        middleware: [
-          offset(8),
-          flip({ fallbackAxisSideDirection: "start", fallbackStrategy: 'initialPlacement'}),
-          shift({ padding: 16 }),
-          !state.noArrow && arrowEl && arrow({ element: arrowEl })]
-      }).then(({ x, y, middlewareData, placement}) => {
-        state.actualDirection = placement
-        console.log("state.actualDirection: ", state.actualDirection);
-        
-        Object.assign(floatingEl.style, {
-          left: `${x}px`,
-          top: `${y}px`,
-        })
-        console.log("placement: ", placement);
-        
-        const side = placement.split("-")[0];
-        
-        const staticSide: any = {
-          top: "bottom",
-          right: "left",
-          bottom: "top",
-          left: "right"
-        }[side];
+      if (!referenceEl || !floatingEl) return
 
-        console.log("side: ", staticSide);
-        
-
-        const isRtl = window.getComputedStyle(floatingEl).direction === 'rtl'
-        const arrowDirection: any = opposites[placement]
-        const arrowPlacement: any = arrowDirection.split("-")[1]
-        const arrowRotation: any = rotation[arrowDirection]
-        
-        if (middlewareData.arrow) {
-          const { x, y } = middlewareData.arrow
-          let top = ''
-          let right = ''
-          let bottom = ''
-          let left = ''
-
-          if (arrowPlacement === "start") {
-            const value = typeof x === 'number' ? `calc(10px - ${arrowEl.offsetWidth / 2}px)` : '';
-            top = typeof y === 'number' ? `calc(10px -  ${arrowEl.offsetWidth / 2}px)` : '';
-            right = isRtl ? value : '';
-            left = isRtl ? '' : value;
-          } else if (arrowPlacement === "end") {
-            const value = typeof x === 'number' ? `calc(10px - ${arrowEl.offsetWidth / 2}px)` : '';
-            right = isRtl ? '' : value;
-            left = isRtl ? value : '';
-            bottom = typeof y === 'number' ? `calc(10px - ${arrowEl.offsetWidth / 2}px)` : '';
-          } else {
-            left = typeof x === 'number' ? `${x}px` : '';
-            top = typeof y === 'number' ? `${y}px` : '';
+        computePosition(referenceEl, floatingEl, {
+          placement: state?.directionName,
+          middleware: [
+            offset(8),
+            flip({ fallbackAxisSideDirection: "start", fallbackStrategy: 'initialPlacement'}),
+            shift({ padding: 16 }),
+            !state?.noArrow && arrowEl && arrow({ element: arrowEl })]
+        }).then(({ x, y, middlewareData, placement}) => {
+          state.actualDirection = placement
+          console.log("state?.actualDirection: ", state?.actualDirection);
+          
+          Object.assign(floatingEl.style, {
+            left: `${x}px`,
+            top: `${y}px`,
+          })
+          
+          const side = placement.split("-")[0];
+          
+          const staticSide: any = {
+            top: "bottom",
+            right: "left",
+            bottom: "top",
+            left: "right"
+          }[side];
+  
+  
+          const isRtl = window.getComputedStyle(floatingEl).direction === 'rtl'
+          const arrowDirection: any = opposites[placement]
+          const arrowPlacement: any = arrowDirection.split("-")[1]
+          const arrowRotation: any = rotation[arrowDirection]
+          
+          if (middlewareData.arrow) {
+            const { x, y } = middlewareData.arrow
+            let top = ''
+            let right = ''
+            let bottom = ''
+            let left = ''
+  
+            if (arrowPlacement === "start") {
+              const value = typeof x === 'number' ? `calc(10px - ${arrowEl?.offsetWidth / 2}px)` : '';
+              top = typeof y === 'number' ? `calc(10px -  ${arrowEl?.offsetWidth / 2}px)` : '';
+              right = isRtl ? value : '';
+              left = isRtl ? '' : value;
+            } else if (arrowPlacement === "end") {
+              const value = typeof x === 'number' ? `calc(10px - ${arrowEl?.offsetWidth / 2}px)` : '';
+              right = isRtl ? '' : value;
+              left = isRtl ? value : '';
+              bottom = typeof y === 'number' ? `calc(10px - ${arrowEl?.offsetWidth / 2}px)` : '';
+            } else {
+              left = typeof x === 'number' ? `${x}px` : '';
+              top = typeof y === 'number' ? `${y}px` : '';
+            }
+  
+            Object.assign(arrowEl?.style || {}, {
+              top,
+              right,
+              bottom,
+              left,
+              [staticSide]: `${-arrowEl?.offsetWidth / 2}px`,
+              transform: `rotate(${arrowRotation}deg)`
+            });
           }
-
-          Object.assign(arrowEl?.style || {}, {
-            top,
-            right,
-            bottom,
-            left,
-            [staticSide]: `${-arrowEl.offsetWidth / 2}px`,
-            transform: `rotate(${arrowRotation}deg)`
-          });
-        }
-      });
+        });
 
       return state
 }
 
 export const autoUpdatePosition = (state: AttentionState) => {
-  const referenceEl: ReferenceElement = state.targetEl as ReferenceElement
-  const floatingEl: HTMLElement = state.attentionEl as HTMLElement
+  const referenceEl: ReferenceElement = state?.targetEl as ReferenceElement
+  const floatingEl: HTMLElement = state?.attentionEl as HTMLElement
   return autoUpdate(referenceEl, floatingEl, () => { useRecompute(state) })
 }

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -115,6 +115,16 @@ export const arrowDirectionClassname = (dir: Directions) => {
   const side = (dir: Directions): Directions => dir.split('-')[0] as Directions
   const staticSide = (dir: Directions): Directions => opposites[side(dir)]
 
+  const applyArrowStyles = (arrowEl: HTMLElement, arrowRotation: number, dir: Directions) => {
+    Object.assign(arrowEl?.style, {
+      borderTopLeftRadius: '4px',
+      zIndex: 1,
+    // border alignment is off by a fraction of a pixel, this fixes it
+      [`margin${arrowDirectionClassname(staticSide(dir))}`]: '-0.5px',
+      transform: `rotate(${arrowRotation}deg)`,
+    });
+  }
+
   function computeCalloutArrow({
     actualDirection,
     directionName = BOTTOM,
@@ -132,12 +142,8 @@ export const arrowDirectionClassname = (dir: Directions) => {
   Object.assign(arrowEl?.style || {}, {
     left: directionIsVertical ? middlePosition : '',
     top: !directionIsVertical ? middlePosition : '',
-    borderTopLeftRadius: '4px',
-    zIndex: 1,
-    // border alignment is off by a fraction of a pixel, this fixes it
-    [`margin${arrowDirectionClassname(staticSide(actualDirection))}`]: '-0.5px',
-    transform: `rotate(${arrowRotation}deg)`,
   })
+  applyArrowStyles(arrowEl, arrowRotation, actualDirection)
 }
 
 export async function useRecompute(state: AttentionState) {
@@ -216,12 +222,8 @@ export async function useRecompute(state: AttentionState) {
         right,
         bottom,
         left,
-        borderTopLeftRadius: '4px',
-        zIndex: 1,
-        // border alignment is off by a fraction of a pixel, this fixes it
-        [`margin${arrowDirectionClassname(staticSide(placement))}`]: '-0.5px',
-        transform: `rotate(${arrowRotation}deg)`,
       })
+      applyArrowStyles(arrowEl, arrowRotation, placement)
     }
   })
 

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -164,12 +164,12 @@ export async function useRecompute (state: AttentionState) {
           });
         }
       });
+
+      return state
 }
 
 export const autoUpdatePosition = (state: AttentionState) => {
   const referenceEl: ReferenceElement = state.targetEl as ReferenceElement
   const floatingEl: HTMLElement = state.attentionEl as HTMLElement
-  console.log("autoUpdatePosition called, ", floatingEl);
-  
   return autoUpdate(referenceEl, floatingEl, () => { useRecompute(state) })
 }

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -132,7 +132,7 @@ export async function useRecompute (state: AttentionState) {
         placement: state.directionName,
         middleware: [
           offset(8),
-          flip({ fallbackAxisSideDirection: state.fallbackDirection, fallbackStrategy: 'initialPlacement'}),
+          flip({ fallbackAxisSideDirection: "start", fallbackStrategy: 'initialPlacement'}),
           shift({ padding: 16 }),
           !state.noArrow && arrowEl && arrow({ element: arrowEl })]
       }).then(({ x, y, middlewareData, placement}) => {

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -100,12 +100,13 @@ export type AttentionState = {
 
 const middlePosition = "calc(50% - 7px)";
 const isDirectionVertical = (name: string) => [TOPSTART, TOP, TOPEND, BOTTOMSTART, BOTTOM, BOTTOMEND].includes(name);
-export function computeCalloutArrow(actualDirection: string, directionName: string, arrowElement: unknown) {
-const arrowEl: HTMLElement = arrowElement as HTMLElement
-  if (!arrowEl) return;
-console.log("inside the computeCalloutArrow?");
-console.log("actualDirection: ", actualDirection);
 
+function computeCalloutArrow({
+  actualDirection,
+  directionName,
+  arrowEl,
+}: AttentionState) {
+  if (!arrowEl) return;
 
   actualDirection = directionName;
   const directionIsVertical = isDirectionVertical(directionName);
@@ -117,10 +118,12 @@ export async function useRecompute (state: AttentionState) {
   if (!state.isShowing)  return // we're not currently showing the element, no reason to recompute
   if (state?.waitForDOM) {
     await state.waitForDOM(); // wait for DOM to settle before computing
-  }  
+  }
+  if (state.isCallout) return computeCalloutArrow(state)
   const referenceEl: ReferenceElement = state.targetEl as ReferenceElement
   const floatingEl: HTMLElement = state.attentionEl as unknown as HTMLElement
   const arrowEl: HTMLElement = state.arrowEl as unknown as HTMLElement
+
   if (!state.noArrow) {
   }
       
@@ -140,7 +143,7 @@ export async function useRecompute (state: AttentionState) {
           left: `${x}px`,
           top: `${y}px`,
         })
-
+        
         // const side = placement.split("-")[0];
 
         // const staticSide = {

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -124,7 +124,7 @@ export async function useRecompute(state: AttentionState) {
     const floatingOffset = arrowEl ? Math.sqrt(2 * arrowEl.offsetWidth ** 2)/ 2 : 8;
   
     if (isMounted) {
-      const cleanup = async () => {
+      const update = async () => {
         const position = await computePosition(
           referenceEl,
           floatingEl,
@@ -158,7 +158,7 @@ export async function useRecompute(state: AttentionState) {
         }
       }
       // computePosition() only positions state.attentionEl once. To ensure it remains anchored to the state.targetEl during a variety of scenarios, for example, when resizing or scrolling, we need to wrap the calculation in autoUpdate:
-      autoUpdate(referenceEl, floatingEl, cleanup)
+      autoUpdate(referenceEl, floatingEl, update)
     }
   }
     return () => {

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -144,7 +144,7 @@ export async function useRecompute(state: AttentionState) {
           left: `${position.x}px`,
           top: `${position.y}px`,
         });
-        
+
         if (position.middlewareData.arrow) {
           // @ts-ignore
           let { x, y } = position.middlewareData.arrow;  
@@ -152,7 +152,7 @@ export async function useRecompute(state: AttentionState) {
 
           Object.assign(arrowEl?.style || {}, {
             left: x ? `${x}px` : "",
-            // temporary fix, for some reasing left-start and right-start positions the arrowEL slightly too far from the attentionEl
+            // temporary fix, for some reason left-start and right-start positions the arrowEL slightly too far from the attentionEl
             top: y ? `${y - 4}px` : "",
           });
         }

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -146,7 +146,7 @@ export async function useRecompute(state: AttentionState) {
 
         if (position.middlewareData.arrow) {
           // @ts-ignore
-          let { x, y } = position.middlewareData.arrow;  
+          const { x, y } = position.middlewareData.arrow;  
 
 
           Object.assign(arrowEl?.style || {}, {

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -86,11 +86,10 @@ const middlePosition: string = 'calc(50% - 7px)'
 const isDirectionVertical = (name: Directions): boolean =>
   ([TOP_START, TOP, TOP_END, BOTTOM_START, BOTTOM, BOTTOM_END] as Directions[]).includes(name)
 
-  const defaultDirectionName: Directions = 'bottom'
 
 function computeCalloutArrow({
   actualDirection,
-  directionName = defaultDirectionName,
+  directionName = BOTTOM,
   arrowEl,
 }: AttentionState) {
   if (!arrowEl) return
@@ -119,7 +118,7 @@ export async function useRecompute(state: AttentionState) {
   const attentionEl: HTMLElement = state?.attentionEl
   
   computePosition(targetEl, attentionEl, {
-    placement: state?.directionName ?? defaultDirectionName,
+    placement: state?.directionName ?? BOTTOM,
     middleware: [
       offset({ mainAxis: state?.distance ?? 8, crossAxis: state?.skidding ?? 0}), // offers flexibility over how to place the attentionEl towards its targetEl both on the x and y axis (horizontally and vertically).
       state?.flip && flip({ //when flip is set to true it will move the attentionEl's placement to its opposite side or to the preferred placements if fallbackPlacements has a value

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -83,12 +83,14 @@ export type AttentionState = {
 }
 
 const middlePosition: string = 'calc(50% - 7px)'
-const isDirectionVertical = (name: Directions) =>
+const isDirectionVertical = (name: Directions): boolean =>
   ([TOP_START, TOP, TOP_END, BOTTOM_START, BOTTOM, BOTTOM_END] as Directions[]).includes(name)
+
+  const defaultDirectionName: Directions = 'bottom'
 
 function computeCalloutArrow({
   actualDirection,
-  directionName = 'bottom',
+  directionName = defaultDirectionName,
   arrowEl,
 }: AttentionState) {
   if (!arrowEl) return
@@ -117,7 +119,7 @@ export async function useRecompute(state: AttentionState) {
   const attentionEl: HTMLElement = state?.attentionEl
   
   computePosition(targetEl, attentionEl, {
-    placement: state?.directionName ?? 'bottom',
+    placement: state?.directionName ?? defaultDirectionName,
     middleware: [
       offset({ mainAxis: state?.distance ?? 8, crossAxis: state?.skidding ?? 0}), // offers flexibility over how to place the attentionEl towards its targetEl both on the x and y axis (horizontally and vertically).
       state?.flip && flip({ //when flip is set to true it will move the attentionEl's placement to its opposite side or to the preferred placements if fallbackPlacements has a value

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -99,20 +99,21 @@ const middlePosition: string = 'calc(50% - 7px)'
 const isDirectionVertical = (name: Directions): boolean =>
   ([TOP_START, TOP, TOP_END, BOTTOM_START, BOTTOM, BOTTOM_END] as Directions[]).includes(name)
 
-export const arrowDirectionClassname = (dir: string) => {
-    let direction: string
+export const arrowDirectionClassname = (dir: Directions) => {
+    let direction: Directions
     if (/-/.test(dir)) {
       direction = dir
         .split('-')
         .map((d) => d.charAt(0).toUpperCase() + d.slice(1))
-        .join('')
+        .join('') as Directions
     } else {
-      direction = dir.charAt(0).toUpperCase() + dir.slice(1)
+      direction = dir.charAt(0).toUpperCase() + dir.slice(1) as Directions
     }
     return `${direction}`
   }
 
-  const side = (actualDirection: Directions): Directions => actualDirection.split('-')[0] as Directions
+  const side = (dir: Directions): Directions => dir.split('-')[0] as Directions
+  const staticSide = (dir: Directions): Directions => opposites[side(dir)]
 
   function computeCalloutArrow({
     actualDirection,
@@ -132,7 +133,7 @@ export const arrowDirectionClassname = (dir: string) => {
     left: directionIsVertical ? middlePosition : '',
     top: !directionIsVertical ? middlePosition : '',
     // border alignment is off by a fraction of a pixel, this fixes it
-    [`margin${arrowDirectionClassname(opposites[side(actualDirection)])}`]: '-0.5px',
+    [`margin${arrowDirectionClassname(staticSide(actualDirection))}`]: '-0.5px',
     transform: `rotate(${arrowRotation}deg)`,
   })
 }
@@ -167,7 +168,6 @@ export async function useRecompute(state: AttentionState) {
       left: `${x}px`,
       top: `${y}px`,
     })
-    const staticSide: Directions = opposites[side(placement)]
     const isRtl = window.getComputedStyle(attentionEl).direction === 'rtl' //checks whether the text direction of the attentionEl is right-to-left. Helps to calculate the position of the arrowEl and ensure proper alignment 
     const arrowDirection: Directions = opposites[placement]
     const arrowPlacement: string = arrowDirection.split('-')[1]
@@ -215,7 +215,7 @@ export async function useRecompute(state: AttentionState) {
         bottom,
         left,
         // border alignment is off by a fraction of a pixel, this fixes it
-        [`margin${arrowDirectionClassname(staticSide)}`]: '-0.5px',
+        [`margin${arrowDirectionClassname(staticSide(placement))}`]: '-0.5px',
         transform: `rotate(${arrowRotation}deg)`,
       })
     }

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -144,13 +144,12 @@ export async function useRecompute(state: AttentionState) {
   const targetEl: ReferenceElement = state?.targetEl
   const attentionEl: HTMLElement = state?.attentionEl
   
-  
   computePosition(targetEl, attentionEl, {
     placement: state?.directionName ?? 'bottom',
     middleware: [
       offset({ mainAxis: state?.distance ?? 8, crossAxis: state?.skidding ?? 0}), // offers flexibility over how to place the attentionEl towards its targetEl both on the x and y axis (horizontally and vertically).
       state?.flip && flip({ //when flip is set to true it will move the attentionEl's placement to its opposite side or to the preferred placements if fallbackPlacements has a value
-        fallbackAxisSideDirection: 'start',
+        fallbackAxisSideDirection: 'start', // the preferred placement axis fit when flip is set to true and fallbackPlacements does not have a value. 'start' represents 'top' or 'left'.
         fallbackPlacements: state?.fallbackPlacements
       }),
       shift({ padding: 16}),

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -112,14 +112,16 @@ console.log("actualDirection: ", actualDirection);
   arrowEl.style.top = !directionIsVertical ? middlePosition : "";
 }
 
-async function useRecompute (state: AttentionState) {
-  console.log("in the useRecompute, state: ", state)
-    if (!state.isShowing)  return // we're not currently showing the element, no reason to recompute
-    if (state?.waitForDOM) {
-      await state.waitForDOM(); // wait for DOM to settle before computing
-    }  
-      const referenceEl: ReferenceElement = state.targetEl as ReferenceElement
-      const floatingEl: HTMLElement = state.attentionEl as unknown as HTMLElement
+async function useRecompute (state: AttentionState) {  
+  if (!state.isShowing)  return // we're not currently showing the element, no reason to recompute
+  if (state?.waitForDOM) {
+    await state.waitForDOM(); // wait for DOM to settle before computing
+  }  
+  const referenceEl: ReferenceElement = state.targetEl as ReferenceElement
+  const floatingEl: HTMLElement = state.attentionEl as unknown as HTMLElement
+  const arrowEl: HTMLElement = state.arrowEl as unknown as HTMLElement
+  if (!state.noArrow) {
+  }
       
       if (!floatingEl) return
       computePosition(referenceEl, floatingEl, {
@@ -128,7 +130,7 @@ async function useRecompute (state: AttentionState) {
           offset(8),
           flip({ fallbackAxisSideDirection: state.fallbackDirection, fallbackStrategy: 'initialPlacement'}),
           shift({ padding: 16 }),
-          !state.noArrow && state.arrowEl && arrow({ element: state.arrowEl as unknown as HTMLElement })]
+          !state.noArrow && arrowEl && arrow({ element: arrowEl })]
       }).then(({ x, y, middlewareData, placement}) => {
         state.actualDirection = placement
         console.log("state.actualDirection: ", state.actualDirection);
@@ -140,20 +142,18 @@ async function useRecompute (state: AttentionState) {
     
         if (middlewareData.arrow) {
           const { x, y } = middlewareData.arrow
-          Object.assign(state.arrowEl?.style || {}, {
+          Object.assign(arrowEl?.style || {}, {
             // TODO: temporary fix, for some reason left-start and right-start positions the arrowEL slightly too far from the attentionEl
             left: x ? placement.includes("-start") ? `${x - 12}px` : `${x}px` : '',
             top: y ? placement.includes("-start") ? `${y - 12}px` : `${y}px` : '',
           });
         }
-      });    
+      });
 }
 
 export const autoUpdatePosition = (state: AttentionState) => {
   const referenceEl: ReferenceElement = state.targetEl as ReferenceElement
   const floatingEl: HTMLElement = state.attentionEl as HTMLElement
-  console.log("kommer vi till autoUpdatePosition")
-  console.log("state: ", state);
   
   
   return autoUpdate(referenceEl, floatingEl, () => { useRecompute(state) })

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -152,7 +152,7 @@ export async function useRecompute(state: AttentionState) {
 
           Object.assign(arrowEl?.style || {}, {
             left: x ? `${x}px` : "",
-            // temporary fix, for some reason left-start and right-start positions the arrowEL slightly too far from the attentionEl
+            // TODO: temporary fix, for some reason left-start and right-start positions the arrowEL slightly too far from the attentionEl
             top: y ? `${y - 4}px` : "",
           });
         }

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -8,7 +8,7 @@ import {
   ReferenceElement,
 } from '@floating-ui/dom'
 
-type Directions =
+export type Directions =
   | 'top'
   | 'top-start'
   | 'top-end'
@@ -51,35 +51,7 @@ export const opposites: Record<Directions, Directions> = {
   [RIGHT_END]: LEFT_START,
 }
 
-export const arrowLabels: Record<Directions, string> = {
-  [TOP_START]: '↑',
-  [TOP]: '↑',
-  [TOP_END]: '↑',
-  [BOTTOM_START]: '↓',
-  [BOTTOM]: '↓',
-  [BOTTOM_END]: '↓',
-  [LEFT_START]: '←',
-  [LEFT]: '←',
-  [LEFT_END]: '←',
-  [RIGHT_START]: '→',
-  [RIGHT]: '→',
-  [RIGHT_END]: '→',
-}
-export const directions: Directions[] = [
-  TOP_START,
-  TOP,
-  TOP_END,
-  BOTTOM_START,
-  BOTTOM,
-  BOTTOM_END,
-  LEFT_START,
-  LEFT,
-  LEFT_END,
-  RIGHT_START,
-  RIGHT,
-  RIGHT_END,
-]
-export const rotation: Record<Directions, number> = {
+const rotation: Record<Directions, number> = {
   [LEFT_START]: -45,
   [LEFT]: -45,
   [LEFT_END]: -45,

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -67,7 +67,7 @@ export const arrowLabels = {
 
 };
 export const directions = [TOPSTART, TOP, TOPEND, BOTTOMSTART, BOTTOM, BOTTOMEND, LEFTSTART, LEFT, LEFTEND, RIGHTSTART, RIGHT, RIGHTEND];
-export const rotation = {
+export const rotation: any = {
   [LEFTSTART]: -45,
   [LEFT]: -45,
   [LEFTEND]: -45,
@@ -109,9 +109,19 @@ function computeCalloutArrow({
   if (!arrowEl) return;
 
   actualDirection = directionName;
+
+  const arrowDirection = opposites[actualDirection]
+  const arrowRotation = rotation[arrowDirection]
+
+  console.log("arrowDirection callout: ", arrowDirection);
+  console.log("arrowRotation callout: ", arrowRotation);
+  
+  
+
   const directionIsVertical = isDirectionVertical(directionName);
   arrowEl.style.left = directionIsVertical ? middlePosition : "";
   arrowEl.style.top = !directionIsVertical ? middlePosition : "";
+  arrowEl.style.transform = `rotate(${arrowRotation}deg)`;
 }
 
 export async function useRecompute (state: AttentionState) {  
@@ -119,10 +129,15 @@ export async function useRecompute (state: AttentionState) {
   if (state?.waitForDOM) {
     await state.waitForDOM(); // wait for DOM to settle before computing
   }
-  if (state.isCallout) return computeCalloutArrow(state)
+  if (state.isCallout) {
+    console.log("kommer vi till callout?");
+    return computeCalloutArrow(state)
+  }
   const referenceEl: ReferenceElement = state.targetEl as ReferenceElement
   const floatingEl: HTMLElement = state.attentionEl as unknown as HTMLElement
   const arrowEl: HTMLElement = state.arrowEl as unknown as HTMLElement
+  console.log("arrowEl: ", arrowEl);
+  
 
   if (!state.noArrow) {
   }
@@ -143,6 +158,7 @@ export async function useRecompute (state: AttentionState) {
           left: `${x}px`,
           top: `${y}px`,
         })
+        console.log("placement: ", placement);
         
         const side = placement.split("-")[0];
         
@@ -153,9 +169,13 @@ export async function useRecompute (state: AttentionState) {
           left: "right"
         }[side];
 
+        console.log("side: ", staticSide);
+        
+
         const isRtl = window.getComputedStyle(floatingEl).direction === 'rtl'
         const arrowDirection: any = opposites[placement]
         const arrowPlacement: any = arrowDirection.split("-")[1]
+        const arrowRotation: any = rotation[arrowDirection]
         
         if (middlewareData.arrow) {
           const { x, y } = middlewareData.arrow
@@ -184,7 +204,8 @@ export async function useRecompute (state: AttentionState) {
             right,
             bottom,
             left,
-            [staticSide]: `${-arrowEl.offsetWidth / 2}px`
+            [staticSide]: `${-arrowEl.offsetWidth / 2}px`,
+            transform: `rotate(${arrowRotation}deg)`
           });
         }
       });

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -124,8 +124,8 @@ export async function useRecompute(state: AttentionState) {
       placement: state.directionName,
       middleware: [
         // Should we make this configurable, but have these as sane defaults?
-        flip(),
         offset(8),
+        flip(),
         shift({ padding: 16 }),
         // @ts-ignore
         arrow({ element: state.noArrow ? undefined : state.arrowEl }), // FIXME
@@ -137,9 +137,6 @@ export async function useRecompute(state: AttentionState) {
   Object.assign(state.attentionEl?.style || {}, {
     left: `${position.x}px`,
     top: `${position.y}px`,
-    // transform: `translate3d(${Math.round(position.x)}px, ${Math.round(
-    //   position.y
-    // )}px, 0)`,
   });
   // @ts-ignore
   let { x, y } = position.middlewareData.arrow;
@@ -147,5 +144,6 @@ export async function useRecompute(state: AttentionState) {
   if (state.arrowEl) {
     state.arrowEl.style.left = x ? x + "px" : "";
     state.arrowEl.style.top = y ? y + "px" : "";
-  }
+    }
+    return position
 }

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -96,6 +96,8 @@ export type AttentionState = {
   callout?: Boolean;
   highlight?: Boolean;
   noArrow?: Boolean;
+  distance?: number;
+  skidding?: number;
   waitForDOM?: () => void;
 };
 
@@ -138,7 +140,7 @@ export async function useRecompute (state: AttentionState) {
         computePosition(referenceEl, floatingEl, {
           placement: state?.directionName,
           middleware: [
-            offset(8),
+            offset({ mainAxis: state?.distance, crossAxis: state?.skidding }),
             flip({ fallbackAxisSideDirection: "start", fallbackStrategy: 'initialPlacement'}),
             shift({ padding: 16 }),
             !state?.noArrow && arrowEl && arrow({ element: arrowEl })]

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -110,7 +110,7 @@ export const arrowDirectionClassname = (dir: Directions) => {
     } else {
       direction = dir.charAt(0).toUpperCase() + dir.slice(1) as Directions
     }
-    return `${direction}`
+    return direction
   }
 
   const side = (dir: Directions): Directions => dir.split('-')[0] as Directions

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -133,17 +133,16 @@ export async function useRecompute(state: AttentionState) {
     }
   );
   // @ts-ignore
- state.actualDirection = position.placement;
+  state.actualDirection = position.placement;
   Object.assign(state.attentionEl?.style || {}, {
     left: `${position.x}px`,
     top: `${position.y}px`,
   });
   // @ts-ignore
   let { x, y } = position.middlewareData.arrow;
-
+  
   if (state.arrowEl) {
     state.arrowEl.style.left = x ? x + "px" : "";
     state.arrowEl.style.top = y ? y + "px" : "";
-    }
-    return position
+  }
 }

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -153,7 +153,7 @@ export async function useRecompute(state: AttentionState) {
           Object.assign(arrowEl?.style || {}, {
             left: x ? `${x}px` : "",
             // TODO: temporary fix, for some reason left-start and right-start positions the arrowEL slightly too far from the attentionEl
-            top: y ? `${y - 4}px` : "",
+            top: y ? position.placement.includes("-start" || "-end") ? `${y - 4}px` : `${y}px` : "",
           });
         }
       }

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -132,6 +132,8 @@ export const arrowDirectionClassname = (dir: Directions) => {
   Object.assign(arrowEl?.style || {}, {
     left: directionIsVertical ? middlePosition : '',
     top: !directionIsVertical ? middlePosition : '',
+    borderTopLeftRadius: '4px',
+    zIndex: 1,
     // border alignment is off by a fraction of a pixel, this fixes it
     [`margin${arrowDirectionClassname(staticSide(actualDirection))}`]: '-0.5px',
     transform: `rotate(${arrowRotation}deg)`,
@@ -214,6 +216,8 @@ export async function useRecompute(state: AttentionState) {
         right,
         bottom,
         left,
+        borderTopLeftRadius: '4px',
+        zIndex: 1,
         // border alignment is off by a fraction of a pixel, this fixes it
         [`margin${arrowDirectionClassname(staticSide(placement))}`]: '-0.5px',
         transform: `rotate(${arrowRotation}deg)`,

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -35,8 +35,6 @@ type Directions =
   | 'left-start'
   | 'left-end'
 
-type FallbackDirection = 'none' | 'start' | 'end'
-
 export const opposites = {
   [TOPSTART]: BOTTOMEND,
   [TOP]: BOTTOM,
@@ -102,7 +100,8 @@ export type AttentionState = {
   directionName?: Directions
   arrowEl?: HTMLElement | null
   attentionEl?: HTMLElement | null
-  fallbackDirection?: FallbackDirection
+  flip?: Boolean
+  fallbackPlacements?: Directions[]
   targetEl?: unknown
   tooltip?: Boolean
   popover?: Boolean
@@ -185,9 +184,10 @@ export async function useRecompute(state: AttentionState) {
     placement: state?.directionName ?? 'bottom',
     middleware: [
       offset({ mainAxis: state?.distance ?? 8, crossAxis: state?.skidding ?? 0}),
-      flip({
+      state?.flip && flip({
         fallbackAxisSideDirection: 'start',
         fallbackStrategy: 'initialPlacement',
+        fallbackPlacements: state?.fallbackPlacements
       }),
       shift({ padding: 16 }),
       !state?.noArrow && arrowEl && arrow({ element: arrowEl }),

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -50,18 +50,18 @@ export const directions: Directions[] = [
   LEFT_END]
 
 export const opposites: Record<Directions, Directions> = {
-  [TOP_START]: BOTTOM_END,
+  [TOP_START]: BOTTOM_START,
   [TOP]: BOTTOM,
-  [TOP_END]: BOTTOM_START,
-  [BOTTOM_START]: TOP_END,
+  [TOP_END]: BOTTOM_END,
+  [BOTTOM_START]: TOP_START,
   [BOTTOM]: TOP,
-  [BOTTOM_END]: TOP_START,
-  [LEFT_START]: RIGHT_END,
+  [BOTTOM_END]: TOP_END,
+  [LEFT_START]: RIGHT_START,
   [LEFT]: RIGHT,
-  [LEFT_END]: RIGHT_START,
-  [RIGHT_START]: LEFT_END,
+  [LEFT_END]: RIGHT_END,
+  [RIGHT_START]: LEFT_START,
   [RIGHT]: LEFT,
-  [RIGHT_END]: LEFT_START,
+  [RIGHT_END]: LEFT_END,
 }
 
 const rotation: Record<Directions, number> = {

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -153,7 +153,7 @@ export async function useRecompute(state: AttentionState) {
           Object.assign(arrowEl?.style || {}, {
             left: x ? `${x}px` : "",
             // TODO: temporary fix, for some reason left-start and right-start positions the arrowEL slightly too far from the attentionEl
-            top: y ? position.placement.includes("-start" || "-end") ? `${y - 4}px` : `${y}px` : "",
+            top: y ? position.placement.includes("-start") ? `${y - 4}px` : `${y}px` : "",
           });
         }
       }

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -144,25 +144,16 @@ export async function useRecompute(state: AttentionState) {
           left: `${position.x}px`,
           top: `${position.y}px`,
         });
-        const side = position.placement.split("-")[0];
         
-        const staticSide: string | any = {
-          top: "bottom",
-          right: "left",
-          bottom: "top",
-          left: "right"
-        }[side];
         if (position.middlewareData.arrow) {
           // @ts-ignore
           let { x, y } = position.middlewareData.arrow;  
+
+
           Object.assign(arrowEl?.style || {}, {
-            left: x !== null ? `${x}px` : "",
-            top: y !== null ? `${y}px` : "",
-            // // Ensure the static side gets unset when
-            // // flipping to other placements' axes.
-            // right: "",
-            // bottom: "",
-            [staticSide]: `${-arrowEl.offsetWidth / 2}px`,
+            left: x ? `${x}px` : "",
+            // temporary fix, for some reasing left-start and right-start positions the arrowEL slightly too far from the attentionEl
+            top: y ? `${y - 4}px` : "",
           });
         }
       }

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -137,7 +137,8 @@ function computeCalloutArrow({
 }
 
 export async function useRecompute(state: AttentionState) {
-  console.log("state.isShowing beginning of useRecompute: ", state.isShowing);
+  console.log("state.isShowing beginning of useRecompute: ", state?.isShowing);
+  
   
   if (!state?.isShowing) return // we're not currently showing the element, no reason to recompute
   if (state?.waitForDOM) {
@@ -181,7 +182,7 @@ export async function useRecompute(state: AttentionState) {
 
 
   computePosition(referenceEl, floatingEl, {
-    placement: state?.directionName,
+    placement: state?.directionName ?? 'bottom',
     middleware: [
       offset({ mainAxis: state?.distance ?? 8, crossAxis: state?.skidding ?? 0}),
       flip({
@@ -262,131 +263,6 @@ export async function useRecompute(state: AttentionState) {
 
   return state
 }
-
-// export async function useRecompute(state: AttentionState) {
-//   console.log("state.isShowing beginning of useRecompute: ", state.isShowing);
-  
-//   if (state?.isCallout) {
-//     return computeCalloutArrow(state)
-//   }
-//   const referenceEl: ReferenceElement = state?.targetEl as ReferenceElement
-//   const floatingEl: HTMLElement = state?.attentionEl as unknown as HTMLElement
-//   const arrowEl: HTMLElement = state?.arrowEl as unknown as HTMLElement
-
-//   if (!referenceEl || !floatingEl) return
-  
-//   if (!state.isShowing) return // we're not currently showing the element, no reason to recompute
-
-//   // We stop computing the position of the floatingEl when referenceEl is no longer visible:
-//   const observer: IntersectionObserver = new IntersectionObserver((entries) => {
-//     for (const entry of entries) {
-//       if (state?.isShowing && !entry.isIntersecting) {
-//         state.isShowing = false
-//         console.log("state.isShowing in observer: ", state.isShowing);
-//       }
-//     }
-//   })
-//   const observedElements = new Set<Element>()
-
-    
-//     if (referenceEl && observedElements.has(referenceEl as Element)) {
-//       console.log("observedElements: ", observedElements);
-//       observer.unobserve(referenceEl as Element)
-//       observedElements.delete(referenceEl as Element)
-//     }
-  
-//   if (state?.waitForDOM) {
-//     await state?.waitForDOM() // wait for DOM to settle before computing
-//   }
-
-//   if (referenceEl && !observedElements.has(referenceEl as Element)) {
-//     observer.observe(referenceEl as Element)
-//     observedElements.add(referenceEl as Element)
-//   }
-
-
-//   computePosition(referenceEl, floatingEl, {
-//     placement: state?.directionName,
-//     middleware: [
-//       offset({ mainAxis: state?.distance ?? 8, crossAxis: state?.skidding ?? 0}),
-//       flip({
-//         fallbackAxisSideDirection: 'start',
-//         fallbackStrategy: 'initialPlacement',
-//       }),
-//       shift({ padding: 16 }),
-//       !state?.noArrow && arrowEl && arrow({ element: arrowEl }),
-//     ],
-//   }).then(({ x, y, middlewareData, placement }) => {
-//     state.actualDirection = placement
-//     console.log('state?.actualDirection: ', state?.actualDirection)
-
-//     Object.assign(floatingEl.style, {
-//       left: `${x}px`,
-//       top: `${y}px`,
-//     })
-
-//     const side = placement.split('-')[0]
-
-//     const staticSide: any = {
-//       top: 'bottom',
-//       right: 'left',
-//       bottom: 'top',
-//       left: 'right',
-//     }[side]
-
-//     const isRtl = window.getComputedStyle(floatingEl).direction === 'rtl'
-//     const arrowDirection: any = opposites[placement]
-//     const arrowPlacement: any = arrowDirection.split('-')[1]
-//     const arrowRotation: any = rotation[arrowDirection]
-
-//     if (middlewareData.arrow) {
-//       const { x, y } = middlewareData.arrow
-//       let top = ''
-//       let right = ''
-//       let bottom = ''
-//       let left = ''
-
-//       // Calculate the arrow-position depending on if placement has '-start' or 'end':
-//       if (arrowPlacement === 'start') {
-//         const value =
-//           typeof x === 'number'
-//             ? `calc(10px - ${arrowEl?.offsetWidth / 2}px)`
-//             : ''
-//         top =
-//           typeof y === 'number'
-//             ? `calc(10px -  ${arrowEl?.offsetWidth / 2}px)`
-//             : ''
-//         right = isRtl ? value : ''
-//         left = isRtl ? '' : value
-//       } else if (arrowPlacement === 'end') {
-//         const value =
-//           typeof x === 'number'
-//             ? `calc(10px - ${arrowEl?.offsetWidth / 2}px)`
-//             : ''
-//         right = isRtl ? '' : value
-//         left = isRtl ? value : ''
-//         bottom =
-//           typeof y === 'number'
-//             ? `calc(10px - ${arrowEl?.offsetWidth / 2}px)`
-//             : ''
-//       } else {
-//         left = typeof x === 'number' ? `${x}px` : ''
-//         top = typeof y === 'number' ? `${y}px` : ''
-//       }
-
-//       Object.assign(arrowEl?.style || {}, {
-//         top,
-//         right,
-//         bottom,
-//         left,
-//         [staticSide]: `${-arrowEl?.offsetWidth / 2}px`,
-//         transform: `rotate(${arrowRotation}deg)`,
-//       })
-//     }
-//   })
-
-//   return state
-// }
 
 export const autoUpdatePosition = (state: AttentionState) => {
   const referenceEl: ReferenceElement = state?.targetEl as ReferenceElement

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -156,10 +156,9 @@ export async function useRecompute(state: AttentionState) {
     middleware: [
       offset({ mainAxis: state?.distance ?? 8, crossAxis: state?.skidding ?? 0}),
       state?.flip && flip({
-        fallbackAxisSideDirection: 'start',
-        fallbackStrategy: 'initialPlacement',
         fallbackPlacements: state?.fallbackPlacements
       }),
+      shift({ padding: 16}),
       !state?.noArrow && arrowEl && arrow({ element: arrowEl }),
     ],
   }).then(({ x, y, middlewareData, placement }) => {

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -37,18 +37,18 @@ type Directions =   | 'top'
 type FallbackDirection = | 'none' | 'start' | 'end';
 
 export const opposites = {
-  [TOPSTART]: BOTTOMSTART,
+  [TOPSTART]: BOTTOMEND,
   [TOP]: BOTTOM,
-  [TOPEND]: BOTTOMEND,
-  [BOTTOMSTART]: TOPSTART,
+  [TOPEND]: BOTTOMSTART,
+  [BOTTOMSTART]: TOPEND,
   [BOTTOM]: TOP,
-  [BOTTOMEND]: TOPEND,
-  [LEFTSTART]: RIGHTSTART,
+  [BOTTOMEND]: TOPSTART,
+  [LEFTSTART]: RIGHTEND,
   [LEFT]: RIGHT,
-  [LEFTEND]: RIGHTEND,
-  [RIGHTSTART]: LEFTSTART,
+  [LEFTEND]: RIGHTSTART,
+  [RIGHTSTART]: LEFTEND,
   [RIGHT]: LEFT,
-  [RIGHTEND]: LEFTEND,
+  [RIGHTEND]: LEFTSTART,
 };
 
 export const arrowLabels = {
@@ -113,7 +113,7 @@ console.log("actualDirection: ", actualDirection);
   arrowEl.style.top = !directionIsVertical ? middlePosition : "";
 }
 
-async function useRecompute (state: AttentionState) {
+export async function useRecompute (state: AttentionState) {  
   if (!state.isShowing)  return // we're not currently showing the element, no reason to recompute
   if (state?.waitForDOM) {
     await state.waitForDOM(); // wait for DOM to settle before computing
@@ -141,11 +141,26 @@ async function useRecompute (state: AttentionState) {
           top: `${y}px`,
         })
 
+        // const side = placement.split("-")[0];
+
+        // const staticSide = {
+        //   top: "bottom",
+        //   right: "left",
+        //   bottom: "top",
+        //   left: "right"
+        // }[side];
+
         if (middlewareData.arrow) {
           const { x, y } = middlewareData.arrow
+          
           Object.assign(arrowEl?.style || {}, {
             left: x ? `${x}px` : '',
             top: y ? `${y}px` : '',
+            // right: "",
+            // bottom: "",
+            // // @ts-ignore
+            // [staticSide]: `${-arrowEl.offsetWidth / 2}px`,
+            // transform: "rotate(45deg)",
           });
         }
       });
@@ -154,7 +169,7 @@ async function useRecompute (state: AttentionState) {
 export const autoUpdatePosition = (state: AttentionState) => {
   const referenceEl: ReferenceElement = state.targetEl as ReferenceElement
   const floatingEl: HTMLElement = state.attentionEl as HTMLElement
-  
+  console.log("autoUpdatePosition called, ", floatingEl);
   
   return autoUpdate(referenceEl, floatingEl, () => { useRecompute(state) })
 }

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -8,19 +8,6 @@ import {
   ReferenceElement,
 } from '@floating-ui/dom'
 
-const TOP_START = 'top-start'
-const TOP = 'top'
-const TOP_END = 'top-end'
-const RIGHT_START = 'right-start'
-const RIGHT = 'right'
-const RIGHT_END = 'right-end'
-const BOTTOM_START = 'bottom-start'
-const BOTTOM = 'bottom'
-const BOTTOM_END = 'bottom-end'
-const LEFT_START = 'left-start'
-const LEFT = 'left'
-const LEFT_END = 'left-end'
-
 type Directions =
   | 'top'
   | 'top-start'
@@ -34,8 +21,22 @@ type Directions =
   | 'left'
   | 'left-start'
   | 'left-end'
+  
+const TOP_START: Directions = 'top-start'
+const TOP: Directions = 'top'
+const TOP_END: Directions = 'top-end'
+const RIGHT_START: Directions = 'right-start'
+const RIGHT: Directions = 'right'
+const RIGHT_END: Directions = 'right-end'
+const BOTTOM_START: Directions = 'bottom-start'
+const BOTTOM: Directions = 'bottom'
+const BOTTOM_END: Directions = 'bottom-end'
+const LEFT_START: Directions = 'left-start'
+const LEFT: Directions = 'left'
+const LEFT_END: Directions = 'left-end'
 
-export const opposites = {
+
+export const opposites: Record<Directions, Directions> = {
   [TOP_START]: BOTTOM_END,
   [TOP]: BOTTOM,
   [TOP_END]: BOTTOM_START,
@@ -50,7 +51,7 @@ export const opposites = {
   [RIGHT_END]: LEFT_START,
 }
 
-export const arrowLabels = {
+export const arrowLabels: Record<Directions, string> = {
   [TOP_START]: '↑',
   [TOP]: '↑',
   [TOP_END]: '↑',
@@ -64,7 +65,7 @@ export const arrowLabels = {
   [RIGHT]: '→',
   [RIGHT_END]: '→',
 }
-export const directions = [
+export const directions: Directions[] = [
   TOP_START,
   TOP,
   TOP_END,
@@ -78,7 +79,7 @@ export const directions = [
   RIGHT,
   RIGHT_END,
 ]
-export const rotation: any = {
+export const rotation: Record<Directions, number> = {
   [LEFT_START]: -45,
   [LEFT]: -45,
   [LEFT_END]: -45,
@@ -109,9 +110,9 @@ export type AttentionState = {
   waitForDOM?: () => void
 }
 
-const middlePosition = 'calc(50% - 7px)'
+const middlePosition: string = 'calc(50% - 7px)'
 const isDirectionVertical = (name: Directions) =>
-  [TOP_START, TOP, TOP_END, BOTTOM_START, BOTTOM, BOTTOM_END].includes(name)
+  ([TOP_START, TOP, TOP_END, BOTTOM_START, BOTTOM, BOTTOM_END] as Directions[]).includes(name)
 
 function computeCalloutArrow({
   actualDirection,
@@ -122,10 +123,10 @@ function computeCalloutArrow({
 
   actualDirection = directionName
 
-  const arrowDirection = opposites[actualDirection]
-  const arrowRotation = rotation[arrowDirection]
+  const arrowDirection: Directions = opposites[actualDirection]
+  const arrowRotation: number = rotation[arrowDirection]
 
-  const directionIsVertical = isDirectionVertical(directionName)
+  const directionIsVertical: boolean = isDirectionVertical(directionName)
   arrowEl.style.left = directionIsVertical ? middlePosition : ''
   arrowEl.style.top = !directionIsVertical ? middlePosition : ''
   arrowEl.style.transform = `rotate(${arrowRotation}deg)`
@@ -140,9 +141,8 @@ export async function useRecompute(state: AttentionState) {
   
   if (!state?.targetEl || !state?.attentionEl) return
   
-  const targetEl = state?.targetEl
-  const attentionEl = state?.attentionEl
-  const arrowEl = state?.arrowEl
+  const targetEl: ReferenceElement = state?.targetEl
+  const attentionEl: HTMLElement = state?.attentionEl
   
   
   computePosition(targetEl, attentionEl, {
@@ -154,38 +154,32 @@ export async function useRecompute(state: AttentionState) {
         fallbackPlacements: state?.fallbackPlacements
       }),
       shift({ padding: 16}),
-      !state?.noArrow && arrowEl && arrow({ element: arrowEl }),
+      !state?.noArrow && state?.arrowEl && arrow({ element: state?.arrowEl }),
     ],
   }).then(({ x, y, middlewareData, placement }) => {
     state.actualDirection = placement
-
-      Object.assign(attentionEl?.style, {
-        left: `${x}px`,
-        top: `${y}px`,
-      })
-
-    const side = placement.split('-')[0]
-
-    const staticSide: any = {
-      top: 'bottom',
-      right: 'left',
-      bottom: 'top',
-      left: 'right',
-    }[side]
-
+    
+    Object.assign(attentionEl?.style, {
+      left: `${x}px`,
+      top: `${y}px`,
+    })
+    
+    const side: Directions = placement.split('-')[0] as Directions
+    const staticSide: Directions = opposites[side]
     const isRtl = window.getComputedStyle(attentionEl).direction === 'rtl' //checks whether the text direction of the attentionEl is right-to-left. Helps to calculate the position of the arrowEl and ensure proper alignment 
-    const arrowDirection: any = opposites[placement]
-    const arrowPlacement: any = arrowDirection.split('-')[1]
-    const arrowRotation: any = rotation[arrowDirection]
-
-    if (middlewareData.arrow && arrowEl) {
+    const arrowDirection: Directions = opposites[placement]
+    const arrowPlacement: string = arrowDirection.split('-')[1]
+    const arrowRotation: number = rotation[arrowDirection]
+    
+    if (middlewareData.arrow && state?.arrowEl) {
+      const arrowEl: HTMLElement = state?.arrowEl
       const { x, y } = middlewareData.arrow
       let top = ''
       let right = ''
       let bottom = ''
       let left = ''
 
-      // calculates the arrow-position depending on if placement has '-start' or 'end'.:
+      // calculates the arrow-position depending on if placement has '-start' or 'end':
       if (arrowPlacement === 'start') {
         const value =
           typeof x === 'number'

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -178,7 +178,7 @@ export async function useRecompute(state: AttentionState) {
       let bottom = ''
       let left = ''
 
-      // calculates the arrow-position depending on if placement has '-start' or 'end':
+      // calculates the arrow-position depending on if placement has 'start' or 'end':
       if (arrowPlacement === 'start') {
         const value =
           typeof x === 'number'
@@ -222,7 +222,7 @@ export async function useRecompute(state: AttentionState) {
 
 export const autoUpdatePosition = (state: AttentionState) => {
   // computePosition is only run once, so we need to wrap autoUpdate() around useRecompute() in order to recompute the attentionEl's position
-  // autoUpdate add event listeners that are triggered on resize and on scroll and will keep calling the useRecompute(). 
+  // autoUpdate adds event listeners that are triggered on resize and on scroll and will keep calling the useRecompute(). 
   // autoUpdate returns a cleanup() function that removes the event listeners.
   if (!state?.targetEl || !state?.attentionEl) return 
   return autoUpdate(state?.targetEl, state?.attentionEl, () => {

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -6,6 +6,7 @@ import {
   arrow,
   autoUpdate,
   ReferenceElement,
+  autoPlacement,
 } from '@floating-ui/dom'
 
 export type Directions =
@@ -163,8 +164,9 @@ export async function useRecompute(state: AttentionState) {
       offset({ mainAxis: state?.distance ?? 8, crossAxis: state?.skidding ?? 0}), // offers flexibility over how to place the attentionEl towards its targetEl both on the x and y axis (horizontally and vertically).
       state?.flip && flip({ //when flip is set to true it will move the attentionEl's placement to its opposite side or to the preferred placements if fallbackPlacements has a value
         fallbackAxisSideDirection: 'start', // the preferred placement axis fit when flip is set to true and fallbackPlacements does not have a value. 'start' represents 'top' or 'left'.
-        fallbackPlacements: state?.fallbackPlacements
+        fallbackPlacements: state?.fallbackPlacements,
       }),
+      !state?.flip && autoPlacement(), // when flip is set to false, it will instead call autoPlacement() that will choose the placement that has the most space available automatically. You can only use either flip() or autoPlacement(), and not combined. 
       shift({ padding: 16}),
       !state?.noArrow && state?.arrowEl && arrow({ element: state?.arrowEl }),
     ],

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -50,6 +50,7 @@ export const opposites = {
   [RIGHT]: LEFT,
   [RIGHTEND]: LEFTEND,
 };
+
 export const arrowLabels = {
   [TOPSTART]: "↑",
   [TOP]: "↑",
@@ -112,7 +113,7 @@ console.log("actualDirection: ", actualDirection);
   arrowEl.style.top = !directionIsVertical ? middlePosition : "";
 }
 
-async function useRecompute (state: AttentionState) {  
+async function useRecompute (state: AttentionState) {
   if (!state.isShowing)  return // we're not currently showing the element, no reason to recompute
   if (state?.waitForDOM) {
     await state.waitForDOM(); // wait for DOM to settle before computing
@@ -139,13 +140,12 @@ async function useRecompute (state: AttentionState) {
           left: `${x}px`,
           top: `${y}px`,
         })
-    
+
         if (middlewareData.arrow) {
           const { x, y } = middlewareData.arrow
           Object.assign(arrowEl?.style || {}, {
-            // TODO: temporary fix, for some reason left-start and right-start positions the arrowEL slightly too far from the attentionEl
-            left: x ? placement.includes("-start") ? `${x - 12}px` : `${x}px` : '',
-            top: y ? placement.includes("-start") ? `${y - 12}px` : `${y}px` : '',
+            left: x ? `${x}px` : '',
+            top: y ? `${y}px` : '',
           });
         }
       });

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -75,7 +75,6 @@ export type AttentionState = {
   actualDirection?: Directions;
   directionName: Directions;
   arrowEl?: HTMLElement | null;
-  attentionEl?: HTMLElement | null;
   waitForDOM?: () => void;
 };
 

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -95,7 +95,8 @@ function computeCalloutArrow({
 
 export async function useRecompute (state: AttentionState, update: () => void) {
     if (!state.isShowing)  return // we're not currently showing the element, no reason to recompute
-      state?.waitForDOM?.(); // wait for DOM to settle before computing
+    // @ts-ignore
+    await state?.waitForDOM; // wait for DOM to settle before computing
       if (state.isCallout) return computeCalloutArrow(state); // we don't move the callout box
       update()
 }

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -144,18 +144,19 @@ export async function useRecompute(state: AttentionState) {
     await state?.waitForDOM() // wait for DOM to settle before computing
   }
   if (state?.isCallout) return computeCalloutArrow(state)
-
+  
   const referenceEl: ReferenceElement = state?.targetEl as ReferenceElement
   const floatingEl: HTMLElement = state?.attentionEl as unknown as HTMLElement
   const arrowEl: HTMLElement = state?.arrowEl as unknown as HTMLElement
   
   if (!referenceEl || !floatingEl) return
- 
+  
   computePosition(referenceEl, floatingEl, {
     placement: state?.directionName ?? 'bottom',
     middleware: [
       offset({ mainAxis: state?.distance ?? 8, crossAxis: state?.skidding ?? 0}),
       state?.flip && flip({
+        fallbackAxisSideDirection: 'start',
         fallbackPlacements: state?.fallbackPlacements
       }),
       shift({ padding: 16}),

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -190,24 +190,24 @@ export async function useRecompute(state: AttentionState) {
       if (arrowPlacement === 'start') {
         const value =
           typeof x === 'number'
-            ? `calc(10px - ${arrowEl?.offsetWidth / 2}px)`
+            ? `calc(33px - ${arrowEl?.offsetWidth / 2}px)`
             : ''
         top =
           typeof y === 'number'
-            ? `calc(10px -  ${arrowEl?.offsetWidth / 2}px)`
+            ? `calc(33px -  ${arrowEl?.offsetWidth / 2}px)`
             : ''
         right = isRtl ? value : ''
         left = isRtl ? '' : value
       } else if (arrowPlacement === 'end') {
         const value =
           typeof x === 'number'
-            ? `calc(10px - ${arrowEl?.offsetWidth / 2}px)`
+            ? `calc(33px - ${arrowEl?.offsetWidth / 2}px)`
             : ''
         right = isRtl ? '' : value
         left = isRtl ? value : ''
         bottom =
           typeof y === 'number'
-            ? `calc(10px - ${arrowEl?.offsetWidth / 2}px)`
+            ? `calc(33px - ${arrowEl?.offsetWidth / 2}px)`
             : ''
       } else {
         left = typeof x === 'number' ? `${x}px` : ''

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -99,7 +99,7 @@ export type AttentionState = {
   isShowing?: boolean
   isCallout?: boolean
   actualDirection?: Directions
-  directionName: Directions
+  directionName?: Directions
   arrowEl?: HTMLElement | null
   attentionEl?: HTMLElement | null
   fallbackDirection?: FallbackDirection
@@ -120,7 +120,7 @@ const isDirectionVertical = (name: string) =>
 
 function computeCalloutArrow({
   actualDirection,
-  directionName,
+  directionName = 'bottom',
   arrowEl,
 }: AttentionState) {
   if (!arrowEl) return

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -95,8 +95,9 @@ function computeCalloutArrow({
 
 export async function useRecompute (state: AttentionState, update: () => void) {
     if (!state.isShowing)  return // we're not currently showing the element, no reason to recompute
-    // @ts-ignore
-    await state?.waitForDOM; // wait for DOM to settle before computing
+    if (state?.waitForDOM) {
+      await state.waitForDOM(); // wait for DOM to settle before computing
+    }  
       if (state.isCallout) return computeCalloutArrow(state); // we don't move the callout box
       update()
 }

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -150,34 +150,7 @@ export async function useRecompute(state: AttentionState) {
   const arrowEl: HTMLElement = state?.arrowEl as unknown as HTMLElement
   
   if (!referenceEl || !floatingEl) return
-  // We stop computing the position of the floatingEl when referenceEl is no longer visible:
-  // const observer: IntersectionObserver = new IntersectionObserver((entries) => {
-  //   for (const entry of entries) {
-  //     if (state?.isShowing && !entry.isIntersecting) {
-  //       console.log("state.isShowing in observer before setting it to false: ", state.isShowing);
-
-  //       state.isShowing = false
-  //       console.log("state.isShowing in observer after setting it to false: ", state.isShowing);
-  //     }
-  //   }
-  // })
-  // const observedElements = new Set<Element>()
-  
-  // if (!state?.isShowing) {
-  //   if (referenceEl && observedElements.has(referenceEl as Element)) {
-  //     observer.unobserve(referenceEl as Element)
-  //     observedElements.delete(referenceEl as Element)
-  //   }
-  //   return // we're not currently showing the element, no reason to recompute
-  // }
-
-
-  // if (referenceEl && !observedElements.has(referenceEl as Element)) {
-  //   observer.observe(referenceEl as Element)
-  //   observedElements.add(referenceEl as Element)
-  // }
-
-
+ 
   computePosition(referenceEl, floatingEl, {
     placement: state?.directionName ?? 'bottom',
     middleware: [
@@ -187,7 +160,6 @@ export async function useRecompute(state: AttentionState) {
         fallbackStrategy: 'initialPlacement',
         fallbackPlacements: state?.fallbackPlacements
       }),
-      shift({ padding: 16 }),
       !state?.noArrow && arrowEl && arrow({ element: arrowEl }),
     ],
   }).then(({ x, y, middlewareData, placement }) => {

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -144,26 +144,47 @@ export async function useRecompute (state: AttentionState) {
           top: `${y}px`,
         })
         
-        // const side = placement.split("-")[0];
+        const side = placement.split("-")[0];
+        
+        const staticSide: any = {
+          top: "bottom",
+          right: "left",
+          bottom: "top",
+          left: "right"
+        }[side];
 
-        // const staticSide = {
-        //   top: "bottom",
-        //   right: "left",
-        //   bottom: "top",
-        //   left: "right"
-        // }[side];
-
+        const isRtl = window.getComputedStyle(floatingEl).direction === 'rtl'
+        const arrowDirection: any = opposites[placement]
+        const arrowPlacement: any = arrowDirection.split("-")[1]
+        
         if (middlewareData.arrow) {
           const { x, y } = middlewareData.arrow
-          
+          let top = ''
+          let right = ''
+          let bottom = ''
+          let left = ''
+
+          if (arrowPlacement === "start") {
+            const value = typeof x === 'number' ? `calc(10px - ${arrowEl.offsetWidth / 2}px)` : '';
+            top = typeof y === 'number' ? `calc(10px -  ${arrowEl.offsetWidth / 2}px)` : '';
+            right = isRtl ? value : '';
+            left = isRtl ? '' : value;
+          } else if (arrowPlacement === "end") {
+            const value = typeof x === 'number' ? `calc(10px - ${arrowEl.offsetWidth / 2}px)` : '';
+            right = isRtl ? '' : value;
+            left = isRtl ? value : '';
+            bottom = typeof y === 'number' ? `calc(10px - ${arrowEl.offsetWidth / 2}px)` : '';
+          } else {
+            left = typeof x === 'number' ? `${x}px` : '';
+            top = typeof y === 'number' ? `${y}px` : '';
+          }
+
           Object.assign(arrowEl?.style || {}, {
-            left: x ? `${x}px` : '',
-            top: y ? `${y}px` : '',
-            // right: "",
-            // bottom: "",
-            // // @ts-ignore
-            // [staticSide]: `${-arrowEl.offsetWidth / 2}px`,
-            // transform: "rotate(45deg)",
+            top,
+            right,
+            bottom,
+            left,
+            [staticSide]: `${-arrowEl.offsetWidth / 2}px`
           });
         }
       });

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -35,6 +35,19 @@ const LEFT_START: Directions = 'left-start'
 const LEFT: Directions = 'left'
 const LEFT_END: Directions = 'left-end'
 
+export const directions: Directions[] = [
+  'top-start',
+  'top',
+  'top-end',
+  'right-start',
+  'right',
+  'right-end',
+  'bottom-start',
+  'bottom',
+  'bottom-end',
+  'left-start',
+  'left',
+  'left-end']
 
 export const opposites: Record<Directions, Directions> = {
   [TOP_START]: BOTTOM_END,

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -113,59 +113,12 @@ function computeCalloutArrow({
   arrowEl.style.top = !directionIsVertical ? middlePosition : "";
 }
 
-// export function updatePosition(state: AttentionState, isMounted: any) {
-//   console.log("Do we get to the start of the updatePosition?, isMounted: ", isMounted);
-  
-//   if (!state.isShowing)  return // we're not currently showing the element, no reason to recompute
-//   if (isMounted === true) {
-//     state?.waitForDOM?.(); // wait for DOM to settle before computing
-//     if (state.isCallout) return computeCalloutArrow(state); // we don't move the callout box
-//     const referenceEl = state.targetEl as ReferenceElement
-//     const floatingEl = state.attentionEl as HTMLElement
-//     const arrowEl = state.arrowEl as HTMLElement
-
-//       autoUpdate(referenceEl, floatingEl, () => {
-//         computePosition(referenceEl, floatingEl, {
-//             placement: state.directionName,
-//             middleware: [
-//               offset(8),
-//               flip(),
-//               shift({ padding: 16 }),
-//               arrowEl && arrow({ element: arrowEl })]
-//           }).then(({ x, y, middlewareData, placement}) => {
-//             if (isMounted === true) {
-//               if (state.isShowing === true) {
-//                 console.log("Do we get here regardless?");
-//                 console.log("true? ", state.isShowing === true);
-                
-//                 state.actualDirection = placement;
-//                 console.log("actualDirection: ", state.actualDirection);
-//                 Object.assign(state.attentionEl?.style || {}, {
-//                   left: `${x}px`,
-//                   top: `${y}px`,
-//                 });
-        
-//                 if (middlewareData.arrow) {
-//                   const { x, y } = middlewareData.arrow;  
-//                   Object.assign(arrowEl?.style || {}, {
-//                     left: x ? `${x}px` : "",
-//                     // TODO: temporary fix, for some reason left-start and right-start positions the arrowEL slightly too far down on the attentionEl
-//                     top: y ? placement.includes("-start") ? `${y - 4}px` : `${y}px` : "",
-//                   });
-//                 }
-//               }
-//             }
-//           });
-//       })
-//   }
-// }
-
 export function useRecompute(state: AttentionState, isMounted: any) {
   console.log("state.isShowing: ", state.isShowing);
   if (isMounted === true) {
     console.log("isMounted true in useRecompute? ", isMounted);
     
-    if (!state.isShowing)  return // we're not currently showing the element, no reason to recompute
+    // if (!state.isShowing)  return // we're not currently showing the element, no reason to recompute
       state?.waitForDOM?.(); // wait for DOM to settle before computing
       if (state.isCallout) return computeCalloutArrow(state); // we don't move the callout box
       const referenceEl = state.targetEl as ReferenceElement
@@ -174,7 +127,7 @@ export function useRecompute(state: AttentionState, isMounted: any) {
 
 
       async function update () {
-        console.log("are we being called by cleanup?");
+        console.log("are we being called by cleanup?, state.isShowing", state.isShowing);
         
         const position = await computePosition(referenceEl, floatingEl, {
           placement: state.directionName,
@@ -208,41 +161,12 @@ export function useRecompute(state: AttentionState, isMounted: any) {
       }
       // @ts-ignore
       const cleanup = autoUpdate(referenceEl, floatingEl, update);
-      if (isMounted === false && !state.isShowing) {
+      if (!state.isShowing) {
         console.log("kommer vi hit?, isMounted: ", isMounted);
        cleanup()
       } else {
         console.log("kommer vi till elsen av useRecompute? ");
         return
       }
-
   }
-  
-
-    // computePosition(referenceEl, floatingEl, {
-    //     placement: state.directionName,
-    //     middleware: [
-    //       offset(8),
-    //       flip(),
-    //       shift({ padding: 16 }),
-    //       arrowEl && arrow({ element: arrowEl })]
-    //   }).then(({ x, y, middlewareData, placement}) => {
-    //     if (state.isShowing) {
-    //       state.actualDirection = placement;
-    //       console.log("actualDirection: ", state.actualDirection);
-    //       Object.assign(state.attentionEl?.style || {}, {
-    //         left: `${x}px`,
-    //         top: `${y}px`,
-    //       });
-  
-    //       if (middlewareData.arrow) {
-    //         const { x, y } = middlewareData.arrow;  
-    //         Object.assign(arrowEl?.style || {}, {
-    //           left: x ? `${x}px` : "",
-    //           // TODO: temporary fix, for some reason left-start and right-start positions the arrowEL slightly too far down on the attentionEl
-    //           top: y ? placement.includes("-start") ? `${y - 4}px` : `${y}px` : "",
-    //         });
-    //       }
-    //     }
-    //   });
 }


### PR DESCRIPTION
**Part of fixes for Jira-tickets:** [WARP-432](https://nmp-jira.atlassian.net/browse/WARP-432), [WARP-341](https://nmp-jira.atlassian.net/browse/WARP-341) & [WARP-373](https://nmp-jira.atlassian.net/browse/WARP-373)

- Update `@floating-ui/dom` to latest version (`1.6.3`)
- Add more `placement`-options for Attention: `top-start`, `top-end`, `right-start`, `right-end`, `left-start`, `left-end`, `bottom-start`, `bottom-end`
- Update type for `Direction` to also include these new placement-options
- Add `distance`, `skidding`, `flip`, `fallbackPlacements` to the attentionState type (Note: these are new props from the AttentionEl and are used in `floating-ui` to give more flexibility for the user when positioning the attentionEl.) 
- Move in the calculation of `arrowRotation` and `arrowDirectionClassname` to the `warp-ds/core` repo instead of having duplicated logic in `warp-ds/react` `warp-ds/vue`, `warp-ds/elements`
- Add more options in the flip-middleware that is part of the `computePosition` (in the `useRecompute` function) so that user can choose whether the attentionEl should flip its placement and if so, which preferred placement should it flip to ( See more detail on how you can configure the middleware in [floating-ui's documentation).](https://floating-ui.com/docs/middleware)
- Remove `transform: `translate3d(${Math.round(position.x)}px, ${Math.round(position.y)}px, 0)`` that was causing the position of the attentionEl to not be aligned correctly. 
- Refactor the calculation of the arrowEl's position to be able to account for when `placement` includes `-start` or `-end` and that it is aligned correctly when the attentionEl's placement is flipped
- Add `autoUpdatePosition` function that uses `floating-ui`'s `autoUpdate` function (See more info on this function [here](https://floating-ui.com/docs/autoUpdate)) that makes it possible to recalculate the attentionEl's placement when resizing the window or on scroll. 


**To test:**
- Link with either `warp-ds/react` (branch: `feat/control-attention-position`), `warp-ds/vue` (branch: `feat/conrol-attention-position`)or `warp-ds/elements` (branch: `feat/control-attention-position`)
- Make sure that `warp-ds/react`, `warp-ds/vue` and `warp-ds/elements` are also linked to `warp-ds/css` (branch: `feat/control-attention-position`). 