### PR TITLE
fix: remove autoplacement(), add crossAxis and hide() to attention helpers.ts

### DIFF
--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -177,8 +177,8 @@ export async function useRecompute(state: AttentionState) {
     state.actualDirection = placement
 
     Object.assign(attentionEl?.style, {
-      top: `${y}px`,
       left: `${x}px`,
+      top: `${y}px`,
     });
 
     if (middlewareData.hide && !state.isTooltip) {      

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -2,7 +2,6 @@ import {
   computePosition,
   flip,
   offset,
-  shift,
   arrow,
   autoUpdate,
   ReferenceElement,
@@ -148,12 +147,6 @@ export const arrowDirectionClassname = (dir: Directions) => {
   applyArrowStyles(arrowEl, arrowRotation(actualDirection), actualDirection)
 }
 
-//roundByDPR ensures that the attentionEl is positioned optimally for the screen, since x and y can contain decimals, which could cause blurring. 
-function roundByDPR(value: number) {
-  const dpr = window.devicePixelRatio || 1;
-  return Math.round(value * dpr) / dpr;
-}
-
 export async function useRecompute(state: AttentionState) {
   if (!state?.isShowing) return // we're not currently showing the element, no reason to recompute
   if (state?.waitForDOM) {
@@ -171,11 +164,9 @@ export async function useRecompute(state: AttentionState) {
     middleware: [
       offset({ mainAxis: state?.distance ?? 8, crossAxis: state?.skidding ?? 0}), // offers flexibility over how to place the attentionEl towards its targetEl both on the x and y axis (horizontally and vertically).
       state?.flip && flip({ //when flip is set to true it will move the attentionEl's placement to its opposite side or to the preferred placements if fallbackPlacements has a value
-        fallbackAxisSideDirection: 'start', // the preferred placement axis fit when flip is set to true and fallbackPlacements does not have a value. 'start' represents 'top' or 'left'.
         crossAxis: state?.crossAxis,
         fallbackPlacements: state?.fallbackPlacements,
       }),
-      shift({ padding: 16}),
       !state?.noArrow && state?.arrowEl && arrow({ element: state?.arrowEl }),
       hide(),
     ],
@@ -183,9 +174,8 @@ export async function useRecompute(state: AttentionState) {
     state.actualDirection = placement
     
     Object.assign(attentionEl?.style, {
-      top: '0',
-      left: '0',
-      transform: `translate(${roundByDPR(x)}px,${roundByDPR(y)}px)`, //use transform styles instead to position the floating element for increased performance.
+      top: `${y}px`,
+      left: `${x}px`,
     });
 
     if (middlewareData.hide && !state.isTooltip) {

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -171,7 +171,7 @@ export async function useRecompute(state: AttentionState) {
       hide({ //will hide the attentionEl when it appears detached from the targetEl. Can be called multiple times in the middleware-array if you want to use several strategies
         strategy: 'escaped', //default strategy is 'referenceHidden'
       }),
-      hide(), // we call hide again here to also trigger the 'referenceHidden' strategy. 
+      hide(), // we call hide() again here to also trigger the 'referenceHidden' strategy. 
     ],
   }).then(({ x, y, middlewareData, placement }) => {
     state.actualDirection = placement

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -164,11 +164,11 @@ export async function useRecompute(state: AttentionState) {
     middleware: [
       offset({ mainAxis: state?.distance ?? 8, crossAxis: state?.skidding ?? 0}), // offers flexibility over how to place the attentionEl towards its targetEl both on the x and y axis (horizontally and vertically).
       state?.flip && flip({ //when flip is set to true it will move the attentionEl's placement to its opposite side or to the preferred placements if fallbackPlacements has a value
-        crossAxis: state?.crossAxis,
+        crossAxis: state?.crossAxis, //checks overflow to trigger a flip. When disabled, it will ignore overflow
         fallbackPlacements: state?.fallbackPlacements,
       }),
       !state?.noArrow && state?.arrowEl && arrow({ element: state?.arrowEl }),
-      hide({
+      hide({ //will hide the attentionEl when it appears detached from the targetEl 
         strategy: 'escaped', //default strategy is 'referenceHidden'
       }),
       hide(),

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -168,23 +168,27 @@ export async function useRecompute(state: AttentionState) {
         fallbackPlacements: state?.fallbackPlacements,
       }),
       !state?.noArrow && state?.arrowEl && arrow({ element: state?.arrowEl }),
+      hide({
+        strategy: 'escaped',
+      }),
       hide(),
     ],
   }).then(({ x, y, middlewareData, placement }) => {
     state.actualDirection = placement
-    
+
     Object.assign(attentionEl?.style, {
       top: `${y}px`,
       left: `${x}px`,
     });
 
-    if (middlewareData.hide && !state.isTooltip) {
+    if (middlewareData.hide && !state.isTooltip) {      
+      const { escaped, referenceHidden } = middlewareData.hide
       Object.assign(attentionEl?.style, {
-        visibility: middlewareData.hide.referenceHidden
-        ? 'hidden'
-        : 'visible',
+        visibility: referenceHidden ? 'hidden' : 'visible',
+        opacity: escaped ? '0.5' : '',
       })
     }
+    
     const isRtl = window.getComputedStyle(attentionEl).direction === 'rtl' //checks whether the text direction of the attentionEl is right-to-left. Helps to calculate the position of the arrowEl and ensure proper alignment 
     const arrowPlacement: string = arrowDirection(placement).split('-')[1]
     

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -167,13 +167,11 @@ export async function useRecompute(state: AttentionState) {
         fallbackPlacements: state?.fallbackPlacements,
       }),
       !state?.noArrow && state?.arrowEl && arrow({ element: state?.arrowEl }),
-      hide({ //will hide the attentionEl when it appears detached from the targetEl. Can be called multiple times in the middleware-array if you want to use several strategies
-        strategy: 'escaped', //default strategy is 'referenceHidden'
-      }),
-      hide(), // we call hide() again here to also trigger the 'referenceHidden' strategy. 
+      hide(), //will hide the attentionEl when it appears detached from the targetEl. Can be called multiple times in the middleware-array if you want to use several strategies. Default strategy is 'referenceHidden'.
     ],
   }).then(({ x, y, middlewareData, placement }) => {
     state.actualDirection = placement
+    console.log("middlewareData?.hide:", middlewareData?.hide);
     
     Object.assign(attentionEl?.style, {
       left: `${x}px`,
@@ -181,10 +179,9 @@ export async function useRecompute(state: AttentionState) {
     });
 
     if (middlewareData?.hide && !state?.isCallout) {      
-      const { escaped, referenceHidden } = middlewareData?.hide
+      const { referenceHidden } = middlewareData?.hide
       Object.assign(attentionEl?.style, {
         visibility: referenceHidden ? 'hidden' : '',
-        opacity: escaped ? '0.5' : '',
       })
     }
     

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -171,7 +171,6 @@ export async function useRecompute(state: AttentionState) {
     ],
   }).then(({ x, y, middlewareData, placement }) => {
     state.actualDirection = placement
-    console.log("middlewareData?.hide:", middlewareData?.hide);
     
     Object.assign(attentionEl?.style, {
       left: `${x}px`,

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -181,8 +181,8 @@ export async function useRecompute(state: AttentionState) {
       top: `${y}px`,
     });
 
-    if (middlewareData.hide && !state.isTooltip) {      
-      const { escaped, referenceHidden } = middlewareData.hide
+    if (middlewareData?.hide && !state?.isTooltip) {      
+      const { escaped, referenceHidden } = middlewareData?.hide
       Object.assign(attentionEl?.style, {
         visibility: referenceHidden ? 'hidden' : 'visible',
         opacity: escaped ? '0.5' : '',

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -82,7 +82,6 @@ const rotation: Record<Directions, number> = {
 export type AttentionState = {
   isShowing?: boolean
   isCallout?: boolean
-  isTooltip?: boolean
   actualDirection?: Directions
   directionName?: Directions
   arrowEl?: HTMLElement | null
@@ -175,16 +174,16 @@ export async function useRecompute(state: AttentionState) {
     ],
   }).then(({ x, y, middlewareData, placement }) => {
     state.actualDirection = placement
-
+    
     Object.assign(attentionEl?.style, {
       left: `${x}px`,
       top: `${y}px`,
     });
 
-    if (middlewareData?.hide && !state?.isTooltip) {      
+    if (middlewareData?.hide && !state?.isCallout) {      
       const { escaped, referenceHidden } = middlewareData?.hide
       Object.assign(attentionEl?.style, {
-        visibility: referenceHidden ? 'hidden' : 'visible',
+        visibility: referenceHidden ? 'hidden' : '',
         opacity: escaped ? '0.5' : '',
       })
     }

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -169,7 +169,7 @@ export async function useRecompute(state: AttentionState) {
       }),
       !state?.noArrow && state?.arrowEl && arrow({ element: state?.arrowEl }),
       hide({
-        strategy: 'escaped',
+        strategy: 'escaped', //default strategy is 'referenceHidden'
       }),
       hide(),
     ],

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -89,6 +89,7 @@ export type AttentionState = {
   arrowEl?: HTMLElement | null
   attentionEl?: HTMLElement | null
   flip?: Boolean
+  crossAxis?: boolean
   fallbackPlacements?: Directions[]
   targetEl?: ReferenceElement | null
   noArrow?: Boolean
@@ -171,7 +172,7 @@ export async function useRecompute(state: AttentionState) {
       offset({ mainAxis: state?.distance ?? 8, crossAxis: state?.skidding ?? 0}), // offers flexibility over how to place the attentionEl towards its targetEl both on the x and y axis (horizontally and vertically).
       state?.flip && flip({ //when flip is set to true it will move the attentionEl's placement to its opposite side or to the preferred placements if fallbackPlacements has a value
         fallbackAxisSideDirection: 'start', // the preferred placement axis fit when flip is set to true and fallbackPlacements does not have a value. 'start' represents 'top' or 'left'.
-        // crossAxis: false,
+        crossAxis: state?.crossAxis,
         fallbackPlacements: state?.fallbackPlacements,
       }),
       shift({ padding: 16}),

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -168,10 +168,10 @@ export async function useRecompute(state: AttentionState) {
         fallbackPlacements: state?.fallbackPlacements,
       }),
       !state?.noArrow && state?.arrowEl && arrow({ element: state?.arrowEl }),
-      hide({ //will hide the attentionEl when it appears detached from the targetEl 
+      hide({ //will hide the attentionEl when it appears detached from the targetEl. Can be called multiple times in the middleware-array if you want to use several strategies
         strategy: 'escaped', //default strategy is 'referenceHidden'
       }),
-      hide(),
+      hide(), // we call hide again here to also trigger the 'referenceHidden' strategy. 
     ],
   }).then(({ x, y, middlewareData, placement }) => {
     state.actualDirection = placement

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -6,7 +6,6 @@ import {
   arrow,
   autoUpdate,
   ReferenceElement,
-  autoPlacement,
 } from '@floating-ui/dom'
 
 export type Directions =
@@ -166,7 +165,6 @@ export async function useRecompute(state: AttentionState) {
         fallbackAxisSideDirection: 'start', // the preferred placement axis fit when flip is set to true and fallbackPlacements does not have a value. 'start' represents 'top' or 'left'.
         fallbackPlacements: state?.fallbackPlacements,
       }),
-      !state?.flip && autoPlacement(), // when flip is set to false, it will instead call autoPlacement() that will choose the placement that has the most space available automatically. You can only use either flip() or autoPlacement(), and not combined. 
       shift({ padding: 16}),
       !state?.noArrow && state?.arrowEl && arrow({ element: state?.arrowEl }),
     ],


### PR DESCRIPTION
**Part of fixes for Jira-tickets:** [WARP-432](https://nmp-jira.atlassian.net/browse/WARP-432), [WARP-341](https://nmp-jira.atlassian.net/browse/WARP-341) & [WARP-373](https://nmp-jira.atlassian.net/browse/WARP-373)

- Remove `autoPlacement()` so that when `flip` is `false` the `attentionEl` will not move.
- Add `crossAxis` to `flip`-middleware and use value from `attentionState`
- Remove `shift()` because it overrides `flip`'s `crossAxis` and contributed to the "buggy" behavior of when `attentionEl` appears to be detached from the `targetEl`
- Add `hide()`-middleware to hide the `attentionEl` when it appears detached from the `targetEl`
- Remove `fallbackAxisSideDirection` from `flip`-middleware since it seemed redundant after adding `hide()`-middleware

**To test:**
Link to either @warp-ds/react (branch: fix/attention-component), @warp-ds/vue (branch: fix/attention-component), @warp-ds/elements (branch: fix/attention-component)
