### PR TITLE
fix: slider acceleration for react

### DIFF
--- a/src/slider/utils/handlers.ts
+++ b/src/slider/utils/handlers.ts
@@ -26,6 +26,11 @@ interface SliderState {
   thumbEl: HTMLDivElement | null;
 }
 
+let keydownRepeat = {
+  counter: 0,
+  repeatsBeforeAcceleration: 3,
+};
+
 export function createHandlers({ props, sliderState }: { props: SliderProps; sliderState: SliderState }) {
   const clampedChange = (n: number) => clamp(n, { max: props.max, min: props.min });
 
@@ -44,11 +49,6 @@ export function createHandlers({ props, sliderState }: { props: SliderProps; sli
   const getShiftedChange = (n: number) => {
     const r = 1.0 / sliderState.step;
     return Math.floor(n * r) / r;
-  };
-
-  const keydownRepeat = {
-    counter: 0,
-    repeatsBeforeAcceleration: 3,
   };
 
   function handleKeyDown(e: KeyboardEvent) {


### PR DESCRIPTION
This acceleration wasn't working because react would initialize the whole `createHandlers` on each re-render. This results in the value of `keydownRepeat.counter` to never increase from it's original value of 0. To fix this we make `createHandlers` an impure function and move the `keydownRepeat` object in the global scope. That makes it possible to update the value on counter even when react re-renders the slider component.

Works in vue as well as react now.