### PR TITLE
fix: add default padding to attention el and fix arrow positioning

### DIFF
--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -138,7 +138,7 @@ export async function useRecompute(state: AttentionState) {
           fallbackPlacements: state?.fallbackPlacements,
         }),
       !state?.noArrow && state?.arrowEl && arrow({ element: state?.arrowEl }),
-      state?.flip && shift({ crossAxis: true }),
+      state?.flip && shift((shiftState) => ({ crossAxis: true, padding: shiftState.rects.reference.width * 0.1 })),
       hide(), // will hide the attentionEl when it appears detached from the targetEl. Can be called multiple times in the middleware-array if you want to use several strategies. Default strategy is 'referenceHidden'.
     ],
   }).then(({ x, y, middlewareData, placement }) => {

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -117,6 +117,9 @@ const applyArrowStyles = (arrowEl: HTMLElement, arrowRotation: number, dir: Dire
   });
 };
 
+const ELEMENT_PADDING = 8;
+const ARROW_OFFSET = 24;
+
 export async function useRecompute(state: AttentionState) {
   if (!state?.isShowing) return; // we're not currently showing the element, no reason to recompute
   if (state?.waitForDOM) {
@@ -144,8 +147,8 @@ export async function useRecompute(state: AttentionState) {
         apply() {
           // Apply equal padding to the left and right sides of the attentionEl to prevent it from overflowing the viewport on smaller screens.
           Object.assign(attentionEl.style, {
-            paddingRight: '8px',
-            paddingLeft: '8px',
+            paddingRight: `${ELEMENT_PADDING}px`,
+            paddingLeft: `${ELEMENT_PADDING}px`,
           });
         },
       }),
@@ -184,15 +187,15 @@ export async function useRecompute(state: AttentionState) {
 
       // Adjust based on 'start' or 'end' placements
       if (arrowPlacement === 'start') {
-        const value = typeof arrowX === 'number' ? `calc(24px - ${arrowEl.offsetWidth / 2}px)` : '';
-        top = typeof arrowY === 'number' ? `calc(24px - ${arrowEl.offsetWidth / 2}px)` : '';
+        const value = typeof arrowX === 'number' ? `calc(${ARROW_OFFSET}px - ${arrowEl.offsetWidth / 2}px)` : '';
+        top = typeof arrowY === 'number' ? `calc(${ARROW_OFFSET}px - ${arrowEl.offsetWidth / 2}px)` : '';
         right = isRtl ? value : '';
         left = isRtl ? '' : value;
       } else if (arrowPlacement === 'end') {
-        const value = typeof arrowX === 'number' ? `calc(24px - ${arrowEl.offsetWidth / 2}px)` : '';
+        const value = typeof arrowX === 'number' ? `calc(${ARROW_OFFSET}px - ${arrowEl.offsetWidth / 2}px)` : '';
         right = isRtl ? '' : value;
         left = isRtl ? value : '';
-        bottom = typeof arrowY === 'number' ? `calc(24px - ${arrowEl.offsetWidth / 2}px)` : '';
+        bottom = typeof arrowY === 'number' ? `calc(${ARROW_OFFSET}px - ${arrowEl.offsetWidth / 2}px)` : '';
       } else {
         // Default positioning with no 'start' or 'end'
         left = typeof arrowX === 'number' ? `${arrowX}px` : '';

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -1,4 +1,4 @@
-import { computePosition, flip, offset, arrow, autoUpdate, ReferenceElement, hide, shift } from '@floating-ui/dom';
+import { computePosition, flip, offset, arrow, autoUpdate, ReferenceElement, hide, shift, size } from '@floating-ui/dom';
 
 export type Directions =
   | 'top'
@@ -138,8 +138,17 @@ export async function useRecompute(state: AttentionState) {
           fallbackPlacements: state?.fallbackPlacements,
         }),
       !state?.noArrow && state?.arrowEl && arrow({ element: state?.arrowEl }),
-      state?.flip && shift((shiftState) => ({ crossAxis: true, padding: shiftState.rects.reference.width * 0.1 })),
+      state?.flip && shift({ crossAxis: true }), // shifts the attentionEl to make sure that it stays in view
       hide(), // will hide the attentionEl when it appears detached from the targetEl. Can be called multiple times in the middleware-array if you want to use several strategies. Default strategy is 'referenceHidden'.
+      size({
+        apply({rects}) {
+          // Apply equal padding to the left and right sides of the attentionEl to prevent it from overflowing the viewport on smaller screens.
+          Object.assign(attentionEl.style, {
+            paddingRight: `${rects.reference.width * 0.15}px`,
+            paddingLeft: `${rects.reference.width * 0.15}px`
+          });
+        },
+      }),
     ],
   }).then(({ x, y, middlewareData, placement }) => {
     state.actualDirection = placement;

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -162,31 +162,30 @@ export async function useRecompute(state: AttentionState) {
       });
     }
 
+    // Handle visibility based on hide middleware
     if (middlewareData?.hide && !state?.isCallout) {
       const { referenceHidden } = middlewareData.hide;
       Object.assign(attentionEl.style, {
         visibility: referenceHidden ? 'hidden' : '',
       });
     }
-    const isRtl = window.getComputedStyle(attentionEl).direction === 'rtl'; // Checks RTL for proper arrow alignment
-    const arrowPlacement: string = arrowDirection(placement).split('-')[1];
 
+    // Arrow position adjustment
     if (middlewareData?.arrow && state?.arrowEl) {
       const arrowEl: HTMLElement = state?.arrowEl as HTMLElement;
       const { x: arrowX, y: arrowY } = middlewareData.arrow;
+      const isRtl = window.getComputedStyle(attentionEl).direction === 'rtl'; // Checks RTL for proper arrow alignment
+      const arrowPlacement: string = arrowDirection(placement).split('-')[1];
 
-      let top = '';
-      let right = '';
-      let bottom = '';
-      let left = '';
+      let top = '',
+        right = '',
+        bottom = '',
+        left = '';
 
-      // Check for shift adjustments
-      const { x: shiftX } = middlewareData.shift || {}; // Get the shift value if it exists
-
-      // Calculate position for 'start' and 'end'
+      // Adjust based on 'start' or 'end' placements
       if (arrowPlacement === 'start') {
         const value = typeof arrowX === 'number' ? `calc(24px - ${arrowEl.offsetWidth / 2}px)` : '';
-        top = typeof arrowY === 'number' ? `calc(24px -  ${arrowEl.offsetWidth / 2}px)` : '';
+        top = typeof arrowY === 'number' ? `calc(24px - ${arrowEl.offsetWidth / 2}px)` : '';
         right = isRtl ? value : '';
         left = isRtl ? '' : value;
       } else if (arrowPlacement === 'end') {
@@ -195,17 +194,18 @@ export async function useRecompute(state: AttentionState) {
         left = isRtl ? value : '';
         bottom = typeof arrowY === 'number' ? `calc(24px - ${arrowEl.offsetWidth / 2}px)` : '';
       } else {
-        // Default placement (with no 'start' or 'end')
+        // Default positioning with no 'start' or 'end'
         left = typeof arrowX === 'number' ? `${arrowX}px` : '';
         top = typeof arrowY === 'number' ? `${arrowY}px` : '';
       }
 
-      // Adjust for cross-axis shift
+      // Adjust for shift if applied
+      const { x: shiftX } = middlewareData.shift || {};
       if (typeof shiftX === 'number') {
         left = typeof arrowX === 'number' ? `${arrowX - shiftX}px` : left;
       }
 
-      // Apply the calculated position
+      // Apply the arrow styles
       Object.assign(arrowEl.style, {
         top,
         right,
@@ -213,6 +213,7 @@ export async function useRecompute(state: AttentionState) {
         left,
       });
 
+      // Apply arrow rotation styles
       applyArrowStyles(arrowEl, arrowRotation(placement), placement);
     }
   });


### PR DESCRIPTION
Fixes JIRA issue: [WARP-607](https://nmp-jira.atlassian.net/browse/WARP-607)

[commit](https://github.com/warp-ds/core/commit/f11690b0ee0d689088b0ff5837053e7711e37e18#diff-f7f359dac756e644d43cfb407c55dca65dc06f8c392dd99f6a13681375c1cc10L162)

**Changes:**
- Add default padding-left and padding-right of 8px to the attention element to prevent viewport overflow on smaller screens.
- Restore the calculation for arrow positioning when the placement includes "start" or "end". This calculation was previously removed ([f11690b](https://github.com/warp-ds/core/commit/f11690b0ee0d689088b0ff5837053e7711e37e18#diff-f7f359dac756e644d43cfb407c55dca65dc06f8c392dd99f6a13681375c1cc10L162)), which caused the arrow to misalign for those placements.
- Combine the arrow positioning calculation with the adjustment for shift() when defined. This ensures that both cross-axis shifts and specific placements ("start", "end") are handled correctly, keeping the arrow aligned with the target element.