### PR TITLE
fix: adjust arrow position misalignment when flip is activated

### DIFF
--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -140,8 +140,8 @@ export async function useRecompute(state: AttentionState) {
           crossAxis: state?.crossAxis, // checks overflow to trigger a flip. When disabled, it will ignore overflow
           fallbackPlacements: state?.fallbackPlacements,
         }),
-      !state?.noArrow && state?.arrowEl && arrow({ element: state?.arrowEl }),
       state?.flip && shift({ crossAxis: true }), // shifts the attentionEl to make sure that it stays in view
+      !state?.noArrow && state?.arrowEl && arrow({ element: state?.arrowEl }),
       hide(), // will hide the attentionEl when it appears detached from the targetEl. Can be called multiple times in the middleware-array if you want to use several strategies. Default strategy is 'referenceHidden'.
       size({
         apply() {
@@ -179,33 +179,31 @@ export async function useRecompute(state: AttentionState) {
       const { x: arrowX, y: arrowY } = middlewareData.arrow;
       const isRtl = window.getComputedStyle(attentionEl).direction === 'rtl'; // Checks RTL for proper arrow alignment
       const arrowPlacement: string = arrowDirection(placement).split('-')[1];
+      const isStart = arrowPlacement === 'start';
+      const isEnd = arrowPlacement === 'end';
 
-      let top = '',
-        right = '',
-        bottom = '',
-        left = '';
+      let top = '';
+      let right = '';
+      let bottom = '';
+      let left = '';
 
       // Adjust based on 'start' or 'end' placements
-      if (arrowPlacement === 'start') {
-        const value = typeof arrowX === 'number' ? `calc(${ARROW_OFFSET}px - ${arrowEl.offsetWidth / 2}px)` : '';
-        top = typeof arrowY === 'number' ? `calc(${ARROW_OFFSET}px - ${arrowEl.offsetWidth / 2}px)` : '';
-        right = isRtl ? value : '';
-        left = isRtl ? '' : value;
-      } else if (arrowPlacement === 'end') {
-        const value = typeof arrowX === 'number' ? `calc(${ARROW_OFFSET}px - ${arrowEl.offsetWidth / 2}px)` : '';
-        right = isRtl ? '' : value;
-        left = isRtl ? value : '';
-        bottom = typeof arrowY === 'number' ? `calc(${ARROW_OFFSET}px - ${arrowEl.offsetWidth / 2}px)` : '';
+      if (isStart || isEnd) {
+        const offsetValue = `${ARROW_OFFSET}px`;
+
+        // Calculate positions based on RTL and arrowX/arrowY
+        if (isStart) {
+          left = isRtl ? '' : `calc(${offsetValue} - ${arrowEl.offsetWidth / 2}px)`;
+          right = isRtl ? `calc(${offsetValue} - ${arrowEl.offsetWidth / 2}px)` : '';
+        } else if (isEnd) {
+          left = isRtl ? `calc(${offsetValue} - ${arrowEl.offsetWidth / 2}px)` : '';
+          right = isRtl ? '' : `calc(${offsetValue} - ${arrowEl.offsetWidth / 2}px)`;
+        }
+        top = typeof arrowY === 'number' ? `${arrowY}px` : top;
       } else {
         // Default positioning with no 'start' or 'end'
         left = typeof arrowX === 'number' ? `${arrowX}px` : '';
         top = typeof arrowY === 'number' ? `${arrowY}px` : '';
-      }
-
-      // Adjust for shift if applied
-      const { x: shiftX } = middlewareData.shift || {};
-      if (typeof shiftX === 'number') {
-        left = typeof arrowX === 'number' ? `${arrowX - shiftX}px` : left;
       }
 
       // Apply the arrow styles

--- a/src/attention/utils/helpers.ts
+++ b/src/attention/utils/helpers.ts
@@ -179,27 +179,23 @@ export async function useRecompute(state: AttentionState) {
       const { x: arrowX, y: arrowY } = middlewareData.arrow;
       const isRtl = window.getComputedStyle(attentionEl).direction === 'rtl'; // Checks RTL for proper arrow alignment
       const arrowPlacement: string = arrowDirection(placement).split('-')[1];
-      const isStart = arrowPlacement === 'start';
-      const isEnd = arrowPlacement === 'end';
 
-      let top = '';
-      let right = '';
-      let bottom = '';
-      let left = '';
+      let top = '',
+        right = '',
+        bottom = '',
+        left = '';
 
       // Adjust based on 'start' or 'end' placements
-      if (isStart || isEnd) {
-        const offsetValue = `${ARROW_OFFSET}px`;
-
-        // Calculate positions based on RTL and arrowX/arrowY
-        if (isStart) {
-          left = isRtl ? '' : `calc(${offsetValue} - ${arrowEl.offsetWidth / 2}px)`;
-          right = isRtl ? `calc(${offsetValue} - ${arrowEl.offsetWidth / 2}px)` : '';
-        } else if (isEnd) {
-          left = isRtl ? `calc(${offsetValue} - ${arrowEl.offsetWidth / 2}px)` : '';
-          right = isRtl ? '' : `calc(${offsetValue} - ${arrowEl.offsetWidth / 2}px)`;
-        }
-        top = typeof arrowY === 'number' ? `${arrowY}px` : top;
+      if (arrowPlacement === 'start') {
+        const value = typeof arrowX === 'number' ? `calc(${ARROW_OFFSET}px - ${arrowEl.offsetWidth / 2}px)` : '';
+        top = typeof arrowY === 'number' ? `calc(${ARROW_OFFSET}px - ${arrowEl.offsetWidth / 2}px)` : '';
+        right = isRtl ? value : '';
+        left = isRtl ? '' : value;
+      } else if (arrowPlacement === 'end') {
+        const value = typeof arrowX === 'number' ? `calc(${ARROW_OFFSET}px - ${arrowEl.offsetWidth / 2}px)` : '';
+        right = isRtl ? '' : value;
+        left = isRtl ? value : '';
+        bottom = typeof arrowY === 'number' ? `calc(${ARROW_OFFSET}px - ${arrowEl.offsetWidth / 2}px)` : '';
       } else {
         // Default positioning with no 'start' or 'end'
         left = typeof arrowX === 'number' ? `${arrowX}px` : '';


### PR DESCRIPTION
Fixes JIRA issue: [WARP-657](https://nmp-jira.atlassian.net/browse/WARP-657)

**Changes include:**
- Moved `shift()` before `arrow()` in the middleware-array. By placing `shift()` before `arrow()`, the position adjustments for the attention-element (`from shift()`) are completed before `arrow()` calculates the arrow's position. This ensures that the arrow aligns correctly with the adjusted placement of the attention-element.
- Removed the custom logic for `shiftX`. By removing the custom `shiftX` logic, we're relying entirely on floating-ui's middleware to handle positioning. This avoids introducing unexpected offset errors, especially for complex placements like `bottom-start` or `left-start`. This custom `shiftX` logic was added before because we needed to manually adjust the arrow's position to compensate for shifts in the attention-element caused by `shift()`. However, by reordering the middleware to place `shift()` before `arrow()`, the `arrow()` middleware now receives the correctly adjusted position of the attention-element, making the manual `shiftX` adjustment redundant and unnecessary.

**Tested** in @warp-ds/react, @warp-ds/vue, and @warp-ds/elements